### PR TITLE
ci: grant contents:write so desktop release publishes

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -22,6 +22,12 @@ on:
     tags:
       - 'v*'
 
+# Needed by softprops/action-gh-release to create the Release and upload the
+# DMG. Without this the default GITHUB_TOKEN is read-only and the release step
+# fails with "Resource not accessible by integration" (403).
+permissions:
+  contents: write
+
 jobs:
   build-macos-arm64:
     runs-on: macos-14  # Apple Silicon runner


### PR DESCRIPTION
## Summary
v1.2.0 桌面构建成功产出 DMG,但「Attach DMG to release」以 **403 Resource not accessible by integration** 失败——默认 `GITHUB_TOKEN` 只读,`softprops/action-gh-release` 无权建 Release(v1.1.0 有 DMG 没 Release 同源)。

加 top-level `permissions: contents: write`,让打 tag 的构建能创建 Release 并上传 DMG。

## Test plan
- [ ] 合并后重打 v1.2.0,确认 desktop-build 全步骤(含 Attach DMG to release)通过并生成 Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)