### PR TITLE
docs: add TakoAPI directory badge

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,5 +1,7 @@
 # AutoClip - 视频高光切片自动化工具
 
+[![Listed on TakoAPI](https://takoapi.com/api/badge/zhouxiaoka-autoclip)](https://takoapi.com/agents/zhouxiaoka-autoclip)
+
 支持YouTube/B站视频下载、自动切片、智能合集生成
 
 [![Python](https://img.shields.io/badge/Python-3.8+-green?style=flat&logo=python)](https://python.org)


### PR DESCRIPTION
Hi! 👋 **autoclip** is listed in the [TakoAPI](https://takoapi.com) open agent directory — a free, open catalog that helps people discover AI-agent projects ("one API to discover all agents").

Your listing: https://takoapi.com/agents/zhouxiaoka-autoclip

This PR adds a small badge near the top of the README that links back to that listing, so visitors can find the directory entry. It's entirely optional — if you'd prefer not to include it, just close this PR (no hard feelings, and apologies for the noise).

No tracking and no obligations. Thanks for building autoclip! 🙏