### PR TITLE
feat(llm): add Atlas Cloud provider

### DIFF
--- a/backend/api/v1/settings.py
+++ b/backend/api/v1/settings.py
@@ -54,6 +54,7 @@ class ApiKeys(BaseModel):
     openai: str = Field(default="", description="OpenAI API密钥")
     gemini: str = Field(default="", description="Gemini API密钥")
     siliconflow: str = Field(default="", description="SiliconFlow API密钥")
+    atlascloud: str = Field(default="", description="Atlas Cloud API密钥")
     jimeng_access: str = Field(default="", description="即梦AI访问密钥")
     jimeng_secret: str = Field(default="", description="即梦AI秘密密钥")
 
@@ -61,6 +62,7 @@ class ApiKeys(BaseModel):
 class ApiSettings(BaseModel):
     """API设置"""
     api_keys: ApiKeys = Field(default_factory=ApiKeys, description="API密钥")
+    api_provider: str = Field(default="dashscope", description="当前LLM提供商")
     api_model: str = Field(default="qwen-plus", description="默认模型")
     api_max_tokens: int = Field(default=4096, description="最大Token数")
     api_timeout: int = Field(default=30, description="API超时时间(秒)")
@@ -210,6 +212,7 @@ async def get_settings():
                     openai=config.openai_api_key,
                     gemini=config.gemini_api_key,
                     siliconflow=config.siliconflow_api_key,
+                    atlascloud=config.atlascloud_api_key,
                     jimeng_access="",  # 默认值
                     jimeng_secret=""   # 默认值
                 ),
@@ -339,6 +342,9 @@ async def test_api_connection(request: TestApiRequest):
         elif request.provider == "siliconflow":
             from backend.core.llm_providers import SiliconFlowProvider
             provider_instance = SiliconFlowProvider(api_key=request.api_key)
+        elif request.provider == "atlascloud":
+            from backend.core.llm_providers import AtlasCloudProvider
+            provider_instance = AtlasCloudProvider(api_key=request.api_key)
         else:
             raise HTTPException(status_code=400, detail="不支持的API提供商")
         
@@ -396,6 +402,7 @@ async def update_settings(settings: DesktopSettings):
         config.openai_api_key = settings.api.api_keys.openai
         config.gemini_api_key = settings.api.api_keys.gemini
         config.siliconflow_api_key = settings.api.api_keys.siliconflow
+        config.atlascloud_api_key = settings.api.api_keys.atlascloud
         config.default_model = settings.api.api_model
         config.max_tokens = settings.api.api_max_tokens
         config.timeout = settings.api.api_timeout
@@ -413,6 +420,9 @@ async def update_settings(settings: DesktopSettings):
         settings_file = config.paths.data_dir / "settings.json"
         with open(settings_file, 'w', encoding='utf-8') as f:
             json.dump(settings.dict(), f, indent=2, ensure_ascii=False)
+
+        from backend.core.llm_manager import initialize_llm_manager
+        initialize_llm_manager(settings_file)
         
         # 重要：保存主配置文件，确保API key等关键配置被持久化
         from backend.core.desktop_config import save_desktop_config
@@ -644,6 +654,9 @@ async def get_available_models():
                 {"name": "qwen-plus", "display_name": "通义千问增强版", "max_tokens": 8192, "description": "通过硅基流动访问"},
                 {"name": "qwen-turbo", "display_name": "通义千问标准版", "max_tokens": 8192, "description": "通过硅基流动访问"}
             ],
+            "atlascloud": [
+                {"name": "deepseek-ai/deepseek-v4-pro", "display_name": "DeepSeek V4 Pro", "max_tokens": 128000, "description": "Atlas Cloud 默认对话模型"}
+            ],
         }
         
         return {"models": models}
@@ -660,13 +673,27 @@ async def get_current_provider():
     try:
         config = get_desktop_config()
         
-        # 根据当前配置返回提供商信息
+        settings_file = config.paths.data_dir / "settings.json"
+        saved_settings = {}
+        if settings_file.exists():
+            with open(settings_file, "r", encoding="utf-8") as source:
+                saved_settings = json.load(source)
+        api_settings = saved_settings.get("api", {})
+        provider = api_settings.get("api_provider", "dashscope")
+        display_names = {
+            "dashscope": "阿里通义千问",
+            "openai": "OpenAI",
+            "gemini": "Google Gemini",
+            "siliconflow": "硅基流动",
+            "atlascloud": "Atlas Cloud",
+        }
+        api_keys = api_settings.get("api_keys", {})
         provider_info = {
-            "provider": "dashscope",  # 默认提供商
-            "model": config.default_model or "qwen-plus",
-            "available": True,
-            "display_name": "通义千问",
-            "description": "阿里云通义千问服务"
+            "provider": provider,
+            "model": api_settings.get("api_model", config.default_model or "qwen-plus"),
+            "available": bool(api_keys.get(provider)),
+            "display_name": display_names.get(provider, provider),
+            "description": f"{display_names.get(provider, provider)} 模型服务"
         }
         
         return provider_info

--- a/backend/core/desktop_config.py
+++ b/backend/core/desktop_config.py
@@ -78,6 +78,7 @@ class DesktopConfig:
         self._openai_api_key = os.getenv("API_OPENAI_API_KEY", "")
         self._gemini_api_key = os.getenv("API_GEMINI_API_KEY", "")
         self._siliconflow_api_key = os.getenv("API_SILICONFLOW_API_KEY", "")
+        self._atlascloud_api_key = os.getenv("ATLASCLOUD_API_KEY", "")
         self._jimeng_access_key = os.getenv("API_JIMENG_ACCESS_KEY", "")
         self._jimeng_secret_key = os.getenv("API_JIMENG_SECRET_KEY", "")
         self._max_memory_usage = int(os.getenv("AUTOCLIP_MAX_MEMORY_USAGE", "2048"))
@@ -233,6 +234,14 @@ class DesktopConfig:
     @siliconflow_api_key.setter
     def siliconflow_api_key(self, value: str) -> None:
         self._siliconflow_api_key = value
+
+    @property
+    def atlascloud_api_key(self) -> str:
+        return self._atlascloud_api_key
+
+    @atlascloud_api_key.setter
+    def atlascloud_api_key(self, value: str) -> None:
+        self._atlascloud_api_key = value
 
     @property
     def jimeng_access_key(self) -> str:

--- a/backend/core/llm_manager.py
+++ b/backend/core/llm_manager.py
@@ -63,12 +63,14 @@ class LLMManager:
     
     def _load_settings(self) -> Dict[str, Any]:
         """加载设置"""
+        has_explicit_provider = False
         default_settings = {
             "llm_provider": "dashscope",
             "dashscope_api_key": "",
             "openai_api_key": "",
             "gemini_api_key": "",
             "siliconflow_api_key": "",
+            "atlascloud_api_key": "",
             "model_name": "qwen-plus",
             "chunk_size": 5000,
             "min_score_threshold": 0.7,
@@ -83,20 +85,33 @@ class LLMManager:
                     # 处理新的配置格式（客户端配置）
                     if "api" in saved_settings and "api_keys" in saved_settings["api"]:
                         api_keys = saved_settings["api"]["api_keys"]
+                        has_explicit_provider = "api_provider" in saved_settings["api"]
                         default_settings.update({
                             "dashscope_api_key": api_keys.get("dashscope", ""),
                             "openai_api_key": api_keys.get("openai", ""),
                             "gemini_api_key": api_keys.get("gemini", ""),
                             "siliconflow_api_key": api_keys.get("siliconflow", ""),
+                            "atlascloud_api_key": api_keys.get("atlascloud", ""),
+                            "llm_provider": saved_settings["api"].get("api_provider", "dashscope"),
                             "model_name": saved_settings["api"].get("api_model", "qwen-plus")
                         })
                     else:
                         # 处理旧的配置格式（直接平铺）
                         default_settings.update(saved_settings)
+                        has_explicit_provider = "llm_provider" in saved_settings
                         
             except Exception as e:
                 logger.warning(f"加载设置文件失败: {e}")
         
+        atlascloud_api_key = os.getenv("ATLASCLOUD_API_KEY", "")
+        if atlascloud_api_key:
+            default_settings["atlascloud_api_key"] = atlascloud_api_key
+            if not has_explicit_provider:
+                default_settings.update({
+                    "llm_provider": "atlascloud",
+                    "model_name": "deepseek-ai/deepseek-v4-pro",
+                })
+
         return default_settings
     
     def _save_settings(self):
@@ -138,11 +153,19 @@ class LLMManager:
             ProviderType.OPENAI: "openai_api_key",
             ProviderType.GEMINI: "gemini_api_key",
             ProviderType.SILICONFLOW: "siliconflow_api_key",
+            ProviderType.ATLASCLOUD: "atlascloud_api_key",
         }
         
         key_name = key_mapping.get(provider_type)
         if key_name:
-            return self.settings.get(key_name, "")
+            api_key = self.settings.get(key_name, "")
+            if api_key:
+                return api_key
+            env_mapping = {
+                ProviderType.ATLASCLOUD: "ATLASCLOUD_API_KEY",
+            }
+            env_name = env_mapping.get(provider_type)
+            return os.getenv(env_name, "") if env_name else ""
         return None
     
     def update_settings(self, new_settings: Dict[str, Any]):
@@ -166,6 +189,7 @@ class LLMManager:
                 ProviderType.OPENAI: "openai_api_key",
                 ProviderType.GEMINI: "gemini_api_key",
                 ProviderType.SILICONFLOW: "siliconflow_api_key",
+                ProviderType.ATLASCLOUD: "atlascloud_api_key",
             }
             
             key_name = key_mapping.get(provider_type)
@@ -243,7 +267,8 @@ class LLMManager:
             ProviderType.DASHSCOPE: "阿里通义千问",
             ProviderType.OPENAI: "OpenAI",
             ProviderType.GEMINI: "Google Gemini",
-            ProviderType.SILICONFLOW: "硅基流动"
+            ProviderType.SILICONFLOW: "硅基流动",
+            ProviderType.ATLASCLOUD: "Atlas Cloud",
         }
         return display_names.get(provider_type, provider_type.value)
     

--- a/backend/core/llm_providers.py
+++ b/backend/core/llm_providers.py
@@ -19,6 +19,7 @@ class ProviderType(Enum):
     OPENAI = "openai"        # OpenAI
     GEMINI = "gemini"        # Google Gemini
     SILICONFLOW = "siliconflow"  # 硅基流动
+    ATLASCLOUD = "atlascloud"  # Atlas Cloud
 
 @dataclass
 class ModelInfo:
@@ -245,9 +246,13 @@ class OpenAIProvider(LLMProvider):
     
     def __init__(self, api_key: str, model_name: str = "gpt-3.5-turbo", **kwargs):
         super().__init__(api_key, model_name, **kwargs)
+        self.base_url = kwargs.get("base_url")
         try:
             import openai
-            self.client = openai.OpenAI(api_key=api_key)
+            client_options = {"api_key": api_key}
+            if self.base_url:
+                client_options["base_url"] = self.base_url
+            self.client = openai.OpenAI(**client_options)
         except ImportError:
             raise ImportError("请安装openai: pip install openai")
     
@@ -322,6 +327,28 @@ class OpenAIProvider(LLMProvider):
                 provider=ProviderType.OPENAI,
                 max_tokens=128000,
                 description="OpenAI GPT-4 Turbo模型"
+            )
+        ]
+
+
+class AtlasCloudProvider(OpenAIProvider):
+    """Atlas Cloud OpenAI-compatible provider."""
+
+    DEFAULT_BASE_URL = "https://api.atlascloud.ai/v1"
+    DEFAULT_MODEL = "deepseek-ai/deepseek-v4-pro"
+
+    def __init__(self, api_key: str, model_name: str = DEFAULT_MODEL, **kwargs):
+        kwargs.setdefault("base_url", self.DEFAULT_BASE_URL)
+        super().__init__(api_key, model_name, **kwargs)
+
+    def get_available_models(self) -> List[ModelInfo]:
+        return [
+            ModelInfo(
+                name=self.DEFAULT_MODEL,
+                display_name="DeepSeek V4 Pro",
+                provider=ProviderType.ATLASCLOUD,
+                max_tokens=128000,
+                description="Atlas Cloud default chat model",
             )
         ]
 
@@ -509,6 +536,7 @@ class LLMProviderFactory:
         ProviderType.OPENAI: OpenAIProvider,
         ProviderType.GEMINI: GeminiProvider,
         ProviderType.SILICONFLOW: SiliconFlowProvider,
+        ProviderType.ATLASCLOUD: AtlasCloudProvider,
     }
     
     @classmethod

--- a/backend/tests/test_atlascloud_provider.py
+++ b/backend/tests/test_atlascloud_provider.py
@@ -1,0 +1,109 @@
+import json
+from types import SimpleNamespace
+
+from backend.core.llm_manager import LLMManager
+from backend.core.llm_providers import (
+    AtlasCloudProvider,
+    LLMProviderFactory,
+    ProviderType,
+)
+
+
+def test_atlascloud_provider_uses_openai_compatible_endpoint(monkeypatch):
+    captured = {}
+
+    class FakeCompletions:
+        def create(self, **kwargs):
+            captured["request"] = kwargs
+            return SimpleNamespace(
+                choices=[SimpleNamespace(
+                    message=SimpleNamespace(content="ok"),
+                    finish_reason="stop",
+                )],
+                usage=None,
+            )
+
+    class FakeOpenAI:
+        def __init__(self, **kwargs):
+            captured["client"] = kwargs
+            self.chat = SimpleNamespace(completions=FakeCompletions())
+
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "openai",
+        SimpleNamespace(OpenAI=FakeOpenAI),
+    )
+
+    provider = AtlasCloudProvider("test-key")
+    response = provider.call("hello")
+
+    assert captured["client"] == {
+        "api_key": "test-key",
+        "base_url": "https://api.atlascloud.ai/v1",
+    }
+    assert captured["request"]["model"] == "deepseek-ai/deepseek-v4-pro"
+    assert response.content == "ok"
+
+
+def test_manager_loads_atlascloud_desktop_settings(monkeypatch, tmp_path):
+    settings_file = tmp_path / "settings.json"
+    settings_file.write_text(json.dumps({
+        "api": {
+            "api_provider": "atlascloud",
+            "api_model": "deepseek-ai/deepseek-v4-pro",
+            "api_keys": {"atlascloud": "test-key"},
+        }
+    }), encoding="utf-8")
+    captured = {}
+
+    def create_provider(provider_type, api_key, model_name, **kwargs):
+        captured.update({
+            "provider_type": provider_type,
+            "api_key": api_key,
+            "model_name": model_name,
+        })
+        return SimpleNamespace()
+
+    monkeypatch.setattr(LLMManager, "_sync_config_if_needed", lambda self: None)
+    monkeypatch.setattr(
+        LLMProviderFactory,
+        "create_provider",
+        staticmethod(create_provider),
+    )
+
+    manager = LLMManager(settings_file)
+
+    assert manager.current_provider is not None
+    assert captured == {
+        "provider_type": ProviderType.ATLASCLOUD,
+        "api_key": "test-key",
+        "model_name": "deepseek-ai/deepseek-v4-pro",
+    }
+
+
+def test_atlascloud_environment_fallback_selects_provider(monkeypatch, tmp_path):
+    monkeypatch.setenv("ATLASCLOUD_API_KEY", "environment-key")
+    monkeypatch.setattr(LLMManager, "_sync_config_if_needed", lambda self: None)
+    captured = {}
+
+    def create_provider(provider_type, api_key, model_name, **kwargs):
+        captured.update({
+            "provider_type": provider_type,
+            "api_key": api_key,
+            "model_name": model_name,
+        })
+        return SimpleNamespace()
+
+    monkeypatch.setattr(
+        LLMProviderFactory,
+        "create_provider",
+        staticmethod(create_provider),
+    )
+
+    LLMManager(tmp_path / "missing-settings.json")
+
+    assert captured == {
+        "provider_type": ProviderType.ATLASCLOUD,
+        "api_key": "environment-key",
+        "model_name": "deepseek-ai/deepseek-v4-pro",
+    }

--- a/frontend/src/hooks/useFirstRun.ts
+++ b/frontend/src/hooks/useFirstRun.ts
@@ -40,7 +40,8 @@ export const useFirstRun = () => {
           const hasApiKey = settings.api?.api_keys?.dashscope || 
                            settings.api?.api_keys?.openai ||
                            settings.api?.api_keys?.gemini ||
-                           settings.api?.api_keys?.siliconflow
+                           settings.api?.api_keys?.siliconflow ||
+                           settings.api?.api_keys?.atlascloud
           
           console.log('🔑 API Key状态:', hasApiKey)
           

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -54,6 +54,14 @@ const SettingsPage: React.FC = () => {
       description: '硅基流动模型服务',
       apiKeyField: 'siliconflow_api_key',
       placeholder: '请输入硅基流动API密钥'
+    },
+    atlascloud: {
+      name: 'Atlas Cloud',
+      icon: <RobotOutlined />,
+      color: '#1677ff',
+      description: 'OpenAI兼容的大模型服务',
+      apiKeyField: 'atlascloud_api_key',
+      placeholder: '请输入Atlas Cloud API密钥'
     }
   }
 
@@ -101,6 +109,7 @@ const SettingsPage: React.FC = () => {
           openai_api_key: settingsData.api?.api_keys?.openai || '',
           gemini_api_key: settingsData.api?.api_keys?.gemini || '',
           siliconflow_api_key: settingsData.api?.api_keys?.siliconflow || '',
+          atlascloud_api_key: settingsData.api?.api_keys?.atlascloud || '',
           jimeng_access_key: settingsData.api?.api_keys?.jimeng_access || '',
           jimeng_secret_key: settingsData.api?.api_keys?.jimeng_secret || '',
           model_name: settingsData.api?.api_model || 'qwen-plus',
@@ -126,6 +135,7 @@ const SettingsPage: React.FC = () => {
           openai_api_key: '',
           gemini_api_key: '',
           siliconflow_api_key: '',
+          atlascloud_api_key: '',
           jimeng_access_key: '',
           jimeng_secret_key: '',
           model_name: 'qwen-plus',
@@ -196,9 +206,11 @@ const SettingsPage: React.FC = () => {
             openai: values.openai_api_key || existingApiKeys.openai || "",
             gemini: values.gemini_api_key || existingApiKeys.gemini || "",
             siliconflow: values.siliconflow_api_key || existingApiKeys.siliconflow || "",
+            atlascloud: values.atlascloud_api_key || existingApiKeys.atlascloud || "",
             jimeng_access: values.jimeng_access_key || existingApiKeys.jimeng_access || "",
             jimeng_secret: values.jimeng_secret_key || existingApiKeys.jimeng_secret || ""
           },
+          api_provider: values.llm_provider || "dashscope",
           api_model: values.model_name || "qwen-plus",
           api_max_tokens: 4096,
           api_timeout: 30
@@ -267,7 +279,10 @@ const SettingsPage: React.FC = () => {
   // 提供商切换
   const handleProviderChange = (provider: string) => {
     setSelectedProvider(provider)
-    form.setFieldsValue({ llm_provider: provider })
+    form.setFieldsValue({
+      llm_provider: provider,
+      ...(provider === 'atlascloud' && { model_name: 'deepseek-ai/deepseek-v4-pro' })
+    })
   }
 
   return (
@@ -394,6 +409,10 @@ const SettingsPage: React.FC = () => {
                       <Select.Option value="gpt-4-turbo">gpt-4-turbo (GPT-4 Turbo)</Select.Option>
                       <Select.Option value="gpt-4">gpt-4 (GPT-4)</Select.Option>
                       <Select.Option value="gpt-3.5-turbo">gpt-3.5-turbo (GPT-3.5 Turbo)</Select.Option>
+                    </Select.OptGroup>
+
+                    <Select.OptGroup label="Atlas Cloud">
+                      <Select.Option value="deepseek-ai/deepseek-v4-pro">deepseek-ai/deepseek-v4-pro (DeepSeek V4 Pro)</Select.Option>
                     </Select.OptGroup>
                     
                     {/* Google Gemini模型 */}

--- a/frontend/src/utils/apiConfigCheck.tsx
+++ b/frontend/src/utils/apiConfigCheck.tsx
@@ -75,6 +75,7 @@ export const checkApiConfig = async (): Promise<ApiConfigStatus> => {
         openai: apiKeys.openai ? '***' + apiKeys.openai.slice(-4) : '未配置',
         gemini: apiKeys.gemini ? '***' + apiKeys.gemini.slice(-4) : '未配置',
         siliconflow: apiKeys.siliconflow ? '***' + apiKeys.siliconflow.slice(-4) : '未配置',
+        atlascloud: apiKeys.atlascloud ? '***' + apiKeys.atlascloud.slice(-4) : '未配置',
         jimeng_access: apiKeys.jimeng_access ? '***' + apiKeys.jimeng_access.slice(-4) : '未配置',
         jimeng_secret: apiKeys.jimeng_secret ? '***' + apiKeys.jimeng_secret.slice(-4) : '未配置'
       }
@@ -104,6 +105,10 @@ export const checkApiConfig = async (): Promise<ApiConfigStatus> => {
         currentApiKey = apiKeys.siliconflow || ''
         hasValidKey = !!currentApiKey.trim()
         console.log('SiliconFlow API Key检查:', { hasKey: !!currentApiKey, keyLength: currentApiKey.length, isValid: hasValidKey })
+        break
+      case 'atlascloud':
+        currentApiKey = apiKeys.atlascloud || ''
+        hasValidKey = !!currentApiKey.trim()
         break
       case 'jimeng':
         currentApiKey = apiKeys.jimeng_access || ''


### PR DESCRIPTION
## Summary

- add Atlas Cloud as a first-class OpenAI-compatible LLM provider
- persist provider selection and Atlas Cloud credentials through desktop settings
- expose the default Atlas Cloud model in the settings UI and runtime model registry
- support `ATLASCLOUD_API_KEY` as a runtime fallback

## Validation

- `python3 -m pytest -q backend/tests` (106 passed)
- `python3 -m pytest -q backend/tests/test_atlascloud_provider.py` (3 passed)
- `python3 -m compileall -q backend`
- `npm run lint`
- `npm run build`
- Atlas Cloud model catalog and live chat completion

`npm run typecheck` still reports six existing `NodeJS.Timeout` versus `number` errors in unrelated polling components.