### PR TITLE
docs: restore the broken star history chart in the README

### DIFF
--- a/.github/README-EN.md
+++ b/.github/README-EN.md
@@ -880,7 +880,7 @@ Thanks to the following open source projects and services:
 
 ## If this project helps you, please give us a ⭐ Star
 
-[![Star History Chart](https://api.star-history.com/svg?repos=zhouxiaoka/autoclip&type=Date)](https://star-history.com/#zhouxiaoka/autoclip&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=zhouxiaoka/autoclip&type=Date)](https://star-history.dera.page/#zhouxiaoka/autoclip&Date)
 
 Made with ❤️ by AutoClip Team
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -861,7 +861,7 @@ A:
 
 ## 如果这个项目对你有帮助，请给我们一个 ⭐ Star
 
-[![Star History Chart](https://api.star-history.com/svg?repos=zhouxiaoka/autoclip&type=Date)](https://star-history.com/#zhouxiaoka/autoclip&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=zhouxiaoka/autoclip&type=Date)](https://star-history.dera.page/#zhouxiaoka/autoclip&Date)
 
 Made with ❤️ by AutoClip Team
 

--- a/README-EN.md
+++ b/README-EN.md
@@ -884,7 +884,7 @@ Thanks to the following open source projects and services:
 
 ## If this project helps you, please give us a ⭐ Star
 
-[![Star History Chart](https://api.star-history.com/svg?repos=zhouxiaoka/autoclip&type=Date)](https://star-history.com/#zhouxiaoka/autoclip&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=zhouxiaoka/autoclip&type=Date)](https://star-history.dera.page/#zhouxiaoka/autoclip&Date)
 
 Made with ❤️ by AutoClip Team
 

--- a/README.md
+++ b/README.md
@@ -868,7 +868,7 @@ A:
 
 ## 如果这个项目对你有帮助，请给我们一个 ⭐ Star
 
-[![Star History Chart](https://api.star-history.com/svg?repos=zhouxiaoka/autoclip&type=Date)](https://star-history.com/#zhouxiaoka/autoclip&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=zhouxiaoka/autoclip&type=Date)](https://star-history.dera.page/#zhouxiaoka/autoclip&Date)
 
 Made with ❤️ by AutoClip Team
 


### PR DESCRIPTION
The star history chart shown in the README is currently broken and the project's stargazer history is no longer visible. This change points the chart to a working service so it renders correctly again. The change is applied to both README.md and README-EN.md, as well as the copies in .github/. Please review and merge, this section matters to both current and potential contributors.