### PR TITLE
fix: make YouTube import work reliably off the original author's machine

### DIFF
--- a/backend/api/v1/youtube.py
+++ b/backend/api/v1/youtube.py
@@ -25,6 +25,17 @@ router = APIRouter()
 download_tasks = {}
 
 
+def _is_cookie_extraction_error(message: str) -> bool:
+    """判断 yt-dlp 失败是否是因为读取不了浏览器 cookie 数据库。
+
+    最常见的场景：选择了 Chrome/Edge 等浏览器作为 cookie 来源，但该浏览器正在运行，
+    独占锁住了 cookie 数据库文件，yt-dlp 复制不出来。这在日常使用中几乎总会发生
+    （浏览器基本总是开着的），不应该让整个解析/下载直接失败。
+    见 https://github.com/yt-dlp/yt-dlp/issues/7271
+    """
+    return "cookie" in (message or "").lower()
+
+
 @contextmanager
 def sanitized_yt_env():
     """临时清理与 yt-dlp 相关的环境变量，避免外部配置影响行为"""
@@ -99,37 +110,40 @@ async def parse_youtube_video(
         def extract_info_sync(url, browser):
             # 构建 yt-dlp 命令：用当前解释器 `-m yt_dlp` 调用，而不是硬编码某个
             # 开发者机器上的绝对路径，这样在任何装了 yt-dlp 包的环境（含 Windows）下都能跑
-            cmd = [
-                sys.executable,
-                '-m', 'yt_dlp',
-                '--ignore-config',
-                '--no-warnings',
-                '--no-playlist',
-                '--dump-json',
-                '--skip-download',  # 修正参数名
-                '--no-cache-dir'
-            ]
-            
-            if browser:
-                cmd.extend(['--cookies-from-browser', browser.lower()])
+            def build_cmd(use_browser: bool):
+                cmd = [
+                    sys.executable,
+                    '-m', 'yt_dlp',
+                    '--ignore-config',
+                    '--no-warnings',
+                    '--no-playlist',
+                    '--dump-json',
+                    '--skip-download',  # 修正参数名
+                    '--no-cache-dir'
+                ]
 
-            # 可选兜底客户端，规避 SABR
-            yt_client = (client or os.getenv('AUTOCLIP_YT_CLIENT', '')).strip().lower()
-            if yt_client in {"android", "ios", "tv"}:
-                cmd.extend(['--extractor-args', f"youtube:player_client={yt_client}"])
-            
-            cmd.append(url)
-            
-            try:
-                # 执行命令（清理环境变量，避免 YT_* 影响）
-                env = os.environ.copy()
-                for k in list(env.keys()):
-                    uk = k.upper()
-                    if uk.startswith('YT_DLP') or uk.startswith('YTDL') or uk.startswith('YOUTUBE_DL') or uk.startswith('YOUTUBEDL'):
-                        env.pop(k, None)
+                if use_browser and browser:
+                    cmd.extend(['--cookies-from-browser', browser.lower()])
 
+                # 可选兜底客户端，规避 SABR
+                yt_client = (client or os.getenv('AUTOCLIP_YT_CLIENT', '')).strip().lower()
+                if yt_client in {"android", "ios", "tv"}:
+                    cmd.extend(['--extractor-args', f"youtube:player_client={yt_client}"])
+
+                cmd.append(url)
+                return cmd
+
+            # 执行命令（清理环境变量，避免 YT_* 影响）
+            env = os.environ.copy()
+            for k in list(env.keys()):
+                uk = k.upper()
+                if uk.startswith('YT_DLP') or uk.startswith('YTDL') or uk.startswith('YOUTUBE_DL') or uk.startswith('YOUTUBEDL'):
+                    env.pop(k, None)
+
+            def run(use_browser: bool):
+                cmd = build_cmd(use_browser)
                 logger.info(f"执行命令: {' '.join(cmd)}")
-                result = subprocess.run(
+                return subprocess.run(
                     cmd,
                     capture_output=True,
                     text=True,
@@ -137,6 +151,15 @@ async def parse_youtube_video(
                     cwd=str(Path(__file__).resolve().parents[3]),
                     env=env
                 )
+
+            try:
+                result = run(use_browser=True)
+
+                # 浏览器 cookie 数据库读取失败（通常是浏览器正在运行中锁住了文件）时，
+                # 不使用 cookie 重试一次，而不是让整个请求直接失败
+                if result.returncode != 0 and browser and _is_cookie_extraction_error(result.stderr or result.stdout):
+                    logger.warning(f"从 {browser} 读取 cookie 失败（可能该浏览器正在运行），改为不使用 cookie 重试")
+                    result = run(use_browser=False)
 
                 logger.info(f"命令返回码: {result.returncode}")
                 logger.info(f"命令输出(前200字): {result.stdout[:200]}...")
@@ -149,7 +172,7 @@ async def parse_youtube_video(
                 # 解析 JSON 输出
                 info_dict = json.loads(result.stdout)
                 return info_dict
-                
+
             except subprocess.TimeoutExpired:
                 raise Exception("yt-dlp timeout")
             except json.JSONDecodeError as e:
@@ -209,9 +232,19 @@ async def create_youtube_download_task(request: YouTubeDownloadRequest):
         
         def extract_info_sync(url, ydl_opts):
             with sanitized_yt_env():
-                with yt_dlp.YoutubeDL(ydl_opts) as ydl:
-                    return ydl.extract_info(url, download=False)
-        
+                try:
+                    with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+                        return ydl.extract_info(url, download=False)
+                except Exception as e:
+                    # 浏览器 cookie 数据库读取失败（通常是浏览器正在运行中锁住了文件）时，
+                    # 不使用 cookie 重试一次，而不是让整个请求直接失败
+                    if ydl_opts.get('cookiesfrombrowser') and _is_cookie_extraction_error(str(e)):
+                        logger.warning(f"读取浏览器 cookie 失败（{e}），改为不使用 cookie 重试")
+                        fallback_opts = {k: v for k, v in ydl_opts.items() if k != 'cookiesfrombrowser'}
+                        with yt_dlp.YoutubeDL(fallback_opts) as ydl:
+                            return ydl.extract_info(url, download=False)
+                    raise
+
         loop = asyncio.get_event_loop()
         video_info = await loop.run_in_executor(None, extract_info_sync, request.url, ydl_opts)
         
@@ -425,9 +458,17 @@ async def process_youtube_download_task(task_id: str, request: YouTubeDownloadRe
         
         def download_sync(url, ydl_opts):
             with sanitized_yt_env():
-                with yt_dlp.YoutubeDL(ydl_opts) as ydl:
-                    return ydl.download([url])
-        
+                try:
+                    with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+                        return ydl.download([url])
+                except Exception as e:
+                    if ydl_opts.get('cookiesfrombrowser') and _is_cookie_extraction_error(str(e)):
+                        logger.warning(f"读取浏览器 cookie 失败（{e}），改为不使用 cookie 重试下载")
+                        fallback_opts = {k: v for k, v in ydl_opts.items() if k != 'cookiesfrombrowser'}
+                        with yt_dlp.YoutubeDL(fallback_opts) as ydl:
+                            return ydl.download([url])
+                    raise
+
         loop = asyncio.get_event_loop()
         await loop.run_in_executor(None, download_sync, request.url, ydl_opts)
         
@@ -704,8 +745,15 @@ async def _try_download_with_different_formats(url: str, download_dir: Path, bro
             
             def download_sync(url, ydl_opts):
                 with sanitized_yt_env():
-                    with yt_dlp.YoutubeDL(ydl_opts) as ydl:
-                        return ydl.download([url])
+                    try:
+                        with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+                            return ydl.download([url])
+                    except Exception as e:
+                        if ydl_opts.get('cookiesfrombrowser') and _is_cookie_extraction_error(str(e)):
+                            fallback_opts = {k: v for k, v in ydl_opts.items() if k != 'cookiesfrombrowser'}
+                            with yt_dlp.YoutubeDL(fallback_opts) as ydl:
+                                return ydl.download([url])
+                        raise
             
             loop = asyncio.get_event_loop()
             await loop.run_in_executor(None, download_sync, url, ydl_opts)
@@ -763,8 +811,15 @@ async def _try_download_with_different_langs(url: str, download_dir: Path, brows
             
             def download_sync(url, ydl_opts):
                 with sanitized_yt_env():
-                    with yt_dlp.YoutubeDL(ydl_opts) as ydl:
-                        return ydl.download([url])
+                    try:
+                        with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+                            return ydl.download([url])
+                    except Exception as e:
+                        if ydl_opts.get('cookiesfrombrowser') and _is_cookie_extraction_error(str(e)):
+                            fallback_opts = {k: v for k, v in ydl_opts.items() if k != 'cookiesfrombrowser'}
+                            with yt_dlp.YoutubeDL(fallback_opts) as ydl:
+                                return ydl.download([url])
+                        raise
             
             loop = asyncio.get_event_loop()
             await loop.run_in_executor(None, download_sync, url, ydl_opts)

--- a/backend/api/v1/youtube.py
+++ b/backend/api/v1/youtube.py
@@ -97,9 +97,11 @@ async def parse_youtube_video(
         import asyncio
         
         def extract_info_sync(url, browser):
-            # 构建 yt-dlp 命令
+            # 构建 yt-dlp 命令：用当前解释器 `-m yt_dlp` 调用，而不是硬编码某个
+            # 开发者机器上的绝对路径，这样在任何装了 yt-dlp 包的环境（含 Windows）下都能跑
             cmd = [
-                '/Users/zhoukk/autoclip/venv/bin/yt-dlp',
+                sys.executable,
+                '-m', 'yt_dlp',
                 '--ignore-config',
                 '--no-warnings',
                 '--no-playlist',
@@ -132,7 +134,7 @@ async def parse_youtube_video(
                     capture_output=True,
                     text=True,
                     timeout=60,
-                    cwd='/Users/zhoukk/autoclip',
+                    cwd=str(Path(__file__).resolve().parents[3]),
                     env=env
                 )
 

--- a/backend/api/v1/youtube.py
+++ b/backend/api/v1/youtube.py
@@ -56,7 +56,10 @@ class YouTubeParseRequest(BaseModel):
 
 class YouTubeDownloadRequest(BaseModel):
     url: str
-    project_name: str
+    # 前端占位符文案承诺"留空将使用视频标题作为项目名称"，所以这里必须是可选的——
+    # 之前是必填 str，留空时前端要么不传该字段（422 "field required"），要么传空
+    # 字符串（下游 ProjectCreate 的 min_length=1 校验直接 500），两条路都是坏的。
+    project_name: Optional[str] = None
     video_category: Optional[str] = "default"
     browser: Optional[str] = None
 
@@ -247,7 +250,10 @@ async def create_youtube_download_task(request: YouTubeDownloadRequest):
 
         loop = asyncio.get_event_loop()
         video_info = await loop.run_in_executor(None, extract_info_sync, request.url, ydl_opts)
-        
+
+        # project_name 留空时，用解析出来的视频标题兜底
+        project_name = (request.project_name or '').strip() or video_info.get('title') or 'Unknown'
+
         # 立即创建项目记录
         from ...core.database import SessionLocal
         from ...services.project_service import ProjectService
@@ -280,7 +286,7 @@ async def create_youtube_download_task(request: YouTubeDownloadRequest):
             
             # 创建项目数据
             project_data = ProjectCreate(
-                name=request.project_name,
+                name=project_name,
                 description=f"从YouTube下载: {video_info.get('title', 'Unknown')}",
                 project_type=ProjectType(request.video_category),
                 status=ProjectStatus.PENDING,  # 初始状态为等待中
@@ -325,7 +331,7 @@ async def create_youtube_download_task(request: YouTubeDownloadRequest):
             task = YouTubeDownloadTask(
                 id=task_id,
                 url=request.url,
-                project_name=request.project_name,
+                project_name=project_name,
                 video_category=request.video_category,
                 status="pending",
                 progress=0.0,
@@ -432,30 +438,16 @@ async def process_youtube_download_task(task_id: str, request: YouTubeDownloadRe
         # 更新项目进度
         await update_project_download_progress(project_id, 30.0, "正在下载视频...")
         
-        # 设置下载选项
-        ydl_opts = {
-            'format': 'bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best',
-            'writesubtitles': True,
-            'writeautomaticsub': True,  # 下载自动生成的字幕
-            'subtitleslangs': ['en', 'zh-Hans', 'zh', 'en-US', 'auto'],  # 英文和中文字幕，包括自动检测
-            'subtitlesformat': 'srt',
-            'outtmpl': str(download_dir / '%(title)s.%(ext)s'),
-            'noplaylist': True,
-            'quiet': True,
-            'no_warnings': False,  # 显示警告信息以便调试
-            'ignoreconfig': True,
-            'config_locations': [],
-            'cachedir': False,
-        }
-        
-        if request.browser:
-            ydl_opts['cookiesfrombrowser'] = (request.browser.lower(),)
-
         # 可选兜底客户端
         yt_client_env = os.getenv('AUTOCLIP_YT_CLIENT', '').strip().lower()
-        if yt_client_env in {"android", "ios", "tv"}:
-            ydl_opts.setdefault('extractor_args', {}).setdefault('youtube', {}).setdefault('player_client', []).append(yt_client_env)
-        
+
+        def apply_common_opts(opts):
+            if request.browser:
+                opts['cookiesfrombrowser'] = (request.browser.lower(),)
+            if yt_client_env in {"android", "ios", "tv"}:
+                opts.setdefault('extractor_args', {}).setdefault('youtube', {}).setdefault('player_client', []).append(yt_client_env)
+            return opts
+
         def download_sync(url, ydl_opts):
             with sanitized_yt_env():
                 try:
@@ -469,19 +461,51 @@ async def process_youtube_download_task(task_id: str, request: YouTubeDownloadRe
                             return ydl.download([url])
                     raise
 
+        # 视频和字幕分两次下载：字幕下载常因限流/无字幕等原因失败，之前两者共用
+        # 一次 yd.download() 调用，字幕环节一抛异常就会连累已经下载成功的视频一起
+        # 报失败。拆开后字幕失败不影响视频，走后面已有的 Whisper 兜底逻辑。
+        video_ydl_opts = apply_common_opts({
+            'format': 'bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best',
+            'outtmpl': str(download_dir / '%(title)s.%(ext)s'),
+            'noplaylist': True,
+            'quiet': True,
+            'no_warnings': False,
+            'ignoreconfig': True,
+            'config_locations': [],
+            'cachedir': False,
+        })
+
         loop = asyncio.get_event_loop()
-        await loop.run_in_executor(None, download_sync, request.url, ydl_opts)
-        
-        # 查找下载的文件
+        await loop.run_in_executor(None, download_sync, request.url, video_ydl_opts)
+
         video_files = list(download_dir.glob("*.mp4"))
-        subtitle_files = list(download_dir.glob("*.srt"))
-        
         if not video_files:
             raise Exception("未找到下载的视频文件")
-        
         video_path = str(video_files[0])
-        subtitle_path = str(subtitle_files[0]) if subtitle_files else ""
-        
+
+        subtitle_path = ""
+        try:
+            subtitle_ydl_opts = apply_common_opts({
+                'skip_download': True,
+                'writesubtitles': True,
+                'writeautomaticsub': True,  # 下载自动生成的字幕
+                'subtitleslangs': ['en', 'zh-Hans', 'zh', 'en-US', 'auto'],  # 英文和中文字幕，包括自动检测
+                'subtitlesformat': 'srt',
+                'outtmpl': str(download_dir / '%(title)s.%(ext)s'),
+                'noplaylist': True,
+                'quiet': True,
+                'no_warnings': False,
+                'ignoreconfig': True,
+                'config_locations': [],
+                'cachedir': False,
+            })
+            await loop.run_in_executor(None, download_sync, request.url, subtitle_ydl_opts)
+            subtitle_files = list(download_dir.glob("*.srt"))
+            subtitle_path = str(subtitle_files[0]) if subtitle_files else ""
+        except Exception as e:
+            logger.warning(f"平台字幕下载失败（{e}），稍后会尝试用 Whisper 生成字幕")
+            subtitle_path = ""
+
         download_tasks[task_id].progress = 80.0
         
         # 更新项目进度
@@ -551,16 +575,16 @@ async def process_youtube_download_task(task_id: str, request: YouTubeDownloadRe
                 raise Exception(f"项目 {project_id} 不存在")
             
             # 更新项目信息
-            project.description = f"从YouTube下载: {request.project_name}"
+            project.description = f"从YouTube下载: {project.name}"
             # 注意：不要在这里设置video_path，等文件移动完成后再设置
-            
+
             # 更新项目设置
             if not project.processing_config:
                 project.processing_config = {}
-            
+
             project.processing_config.update({
                 "youtube_info": {
-                    "title": request.project_name,
+                    "title": project.name,
                     "uploader": "YouTube",
                     "duration": 0,
                     "view_count": 0,
@@ -577,10 +601,12 @@ async def process_youtube_download_task(task_id: str, request: YouTubeDownloadRe
             raw_dir = project_dir / "raw"
             raw_dir.mkdir(parents=True, exist_ok=True)
             
-            # 移动视频文件到项目目录
+            # 移动视频文件到项目目录（Path 已在模块顶部导入，这里不要重复 import——
+            # 函数体内任何位置对某个名字做局部 import/赋值，都会让该名字在整个函数
+            # 作用域内被视为局部变量，导致本函数更早处的 Path(...) 调用抛
+            # UnboundLocalError）
             import shutil
-            from pathlib import Path
-            
+
             if video_path:
                 video_file_path = Path(video_path)
                 if video_file_path.exists():


### PR DESCRIPTION
## Summary
Reliability fixes for `backend/api/v1/youtube.py`, found by actually running YouTube import end-to-end on a Windows machine other than the original author's — including a full real-world run (~30 minute video, no captions available, Whisper fallback, full AI pipeline).

1. **Hardcoded developer-machine path.** `parse_youtube_video()` shelled out to yt-dlp via a hardcoded absolute path (`/Users/zhoukk/autoclip/venv/bin/yt-dlp`) and hardcoded `cwd`. On any other machine this failed immediately with `[WinError 2] The system cannot find the file specified` (or the POSIX equivalent). Fixed by invoking yt-dlp as `sys.executable -m yt_dlp` with `cwd` resolved relative to the file's own location.

2. **Cookie-extraction failure has no fallback.** Selecting a browser as the cookie source makes yt-dlp try to copy that browser's cookie database. If the browser is running — the normal state — the database is typically locked and the copy fails outright (`ERROR: Could not copy Chrome cookie database`, see yt-dlp#7271). Fixed by catching cookie-extraction failures and retrying once without cookies instead of failing the whole request.

3. **A subtitle-download failure took the whole download down with it**, including a video file that had already downloaded successfully. Split video and subtitle downloads into two separate yt-dlp calls, so a subtitle-side failure (rate limiting, no captions, etc.) can no longer abort the video download — this also lets the existing Whisper fallback actually run, since previously the function raised before ever reaching that fallback logic.

4. **`UnboundLocalError: cannot access local variable 'Path'`** — a redundant `from pathlib import Path` partway through `process_youtube_download_task()` shadowed the module-level import for the function's *entire* scope, breaking an earlier `Path(...)` call above it. Removed the redundant import.

5. **`project_name` was required with no default**, but the frontend's own placeholder text promises "leave blank to use the video title" and only sends the field when non-empty. Left blank (as invited), this always failed — either FastAPI's "field required" or, for an explicit empty string, `ProjectCreate`'s `min_length=1` validator. Made it optional, falling back to the parsed video title, matching what the UI already promises.

## Test plan
- [x] Reproduced and fixed the hardcoded-path failure; confirmed `/parse` and `/download` work end-to-end with a real YouTube URL.
- [x] Reproduced the cookie-extraction failure (`browser=chrome`, browser not installed/locked); confirmed automatic fallback without cookies succeeds.
- [x] Ran a full real ~30-minute video through the pipeline end-to-end: video download succeeded even when platform subtitles hit `HTTP 429`; Whisper fallback correctly kicked in and produced accurate transcription; project created with the video's title when left blank; full AI pipeline (outline → timeline → scoring → titling → clustering → cutting) completed and produced real, valid clips.

https://claude.ai/code/session_01UhcqhMkK2bg9c7h8t7rY95