### PR TITLE
fix: Gemini provider offered deprecated model names that 404

### DIFF
--- a/backend/core/llm_providers.py
+++ b/backend/core/llm_providers.py
@@ -328,7 +328,7 @@ class OpenAIProvider(LLMProvider):
 class GeminiProvider(LLMProvider):
     """Google Gemini提供商"""
     
-    def __init__(self, api_key: str, model_name: str = "gemini-2.5-flash", **kwargs):
+    def __init__(self, api_key: str, model_name: str = "gemini-flash-latest", **kwargs):
         super().__init__(api_key, model_name, **kwargs)
         try:
             # New unified Google GenAI SDK (replaces the deprecated
@@ -380,28 +380,34 @@ class GeminiProvider(LLMProvider):
             return False
     
     def get_available_models(self) -> List[ModelInfo]:
-        """获取Gemini可用模型"""
+        """获取Gemini可用模型
+
+        用 Google 官方维护的 "-latest" 别名而不是具体的带日期/版本号的型号名
+        （如 gemini-2.5-flash、gemini-1.5-pro）。这些具体型号会被 Google 下线，
+        下线后调用直接 404（此前就因为 gemini-2.5-flash 被下线而踩过一次），
+        "-latest" 别名会由 Google 一直指向当前可用的模型，不需要再手动跟着改。
+        """
         return [
             ModelInfo(
-                name="gemini-2.5-flash",
-                display_name="Gemini 2.5 Flash",
+                name="gemini-flash-latest",
+                display_name="Gemini Flash (latest)",
                 provider=ProviderType.GEMINI,
                 max_tokens=1000000,
-                description="Google Gemini 2.5 Flash模型"
+                description="Google Gemini 最新 Flash 模型（速度与成本均衡）"
             ),
             ModelInfo(
-                name="gemini-1.5-pro",
-                display_name="Gemini 1.5 Pro",
+                name="gemini-pro-latest",
+                display_name="Gemini Pro (latest)",
                 provider=ProviderType.GEMINI,
                 max_tokens=2000000,
-                description="Google Gemini 1.5 Pro模型"
+                description="Google Gemini 最新 Pro 模型（更强推理能力）"
             ),
             ModelInfo(
-                name="gemini-1.5-flash",
-                display_name="Gemini 1.5 Flash",
+                name="gemini-flash-lite-latest",
+                display_name="Gemini Flash-Lite (latest)",
                 provider=ProviderType.GEMINI,
                 max_tokens=1000000,
-                description="Google Gemini 1.5 Flash模型"
+                description="Google Gemini 最新 Flash-Lite 模型（最快最省）"
             )
         ]
 

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -396,11 +396,12 @@ const SettingsPage: React.FC = () => {
                       <Select.Option value="gpt-3.5-turbo">gpt-3.5-turbo (GPT-3.5 Turbo)</Select.Option>
                     </Select.OptGroup>
                     
-                    {/* Google Gemini模型 */}
+                    {/* Google Gemini模型：用官方维护的 "-latest" 别名而不是具体版本号
+                        （如 gemini-1.5-pro），避免版本被 Google 下线后调用直接 404 */}
                     <Select.OptGroup label="Google Gemini">
-                      <Select.Option value="gemini-1.5-pro">gemini-1.5-pro (Gemini 1.5 Pro)</Select.Option>
-                      <Select.Option value="gemini-1.5-flash">gemini-1.5-flash (Gemini 1.5 Flash)</Select.Option>
-                      <Select.Option value="gemini-pro">gemini-pro (Gemini Pro)</Select.Option>
+                      <Select.Option value="gemini-flash-latest">gemini-flash-latest (Gemini Flash，速度与成本均衡)</Select.Option>
+                      <Select.Option value="gemini-pro-latest">gemini-pro-latest (Gemini Pro，更强推理能力)</Select.Option>
+                      <Select.Option value="gemini-flash-lite-latest">gemini-flash-lite-latest (Gemini Flash-Lite，最快最省)</Select.Option>
                     </Select.OptGroup>
                     
                     {/* 硅基流动模型 */}


### PR DESCRIPTION
## Summary
`GeminiProvider`'s default model and its `get_available_models()` list (also mirrored in the frontend Settings dropdown) used dated Gemini model names like `gemini-2.5-flash` and `gemini-1.5-pro`. Google has since deprecated these for new users — calling them now fails with:

```
404 NOT_FOUND. This model models/gemini-2.5-flash is no longer available to
new users. Please update your code to use models/gemini-3.6-flash for the
latest features and improvements.
```

So configuring Gemini through Settings and picking any of the offered models failed outright.

Switched to Google's officially-maintained `-latest` aliases (`gemini-flash-latest`, `gemini-pro-latest`, `gemini-flash-lite-latest`) instead of dated version numbers, so this doesn't go stale again the next time Google rotates model versions.

## Test plan
- [x] Confirmed `gemini-2.5-flash` and `gemini-1.5-pro` both 404 immediately against a real API key.
- [x] Verified all three `-latest` aliases directly against the Gemini API with a real key — they respond with 503 (overloaded) or 429 (quota) under load, never 404, confirming they're valid current models.
- [x] Ran a full real video through AutoClip's pipeline end-to-end with `gemini-flash-latest`: outline extraction → timeline → scoring → titling → clustering → video cutting all completed and produced real, valid clips.

https://claude.ai/code/session_01UhcqhMkK2bg9c7h8t7rY95