### PR TITLE
fix: log FileHandlers crash on non-ASCII log lines without explicit encoding

### DIFF
--- a/backend/app_factory.py
+++ b/backend/app_factory.py
@@ -34,7 +34,7 @@ def create_app(mode: str = "web") -> FastAPI:
         format=logging_config["format"],
         handlers=[
             logging.StreamHandler(),
-            logging.FileHandler(logging_config["file"])
+            logging.FileHandler(logging_config["file"], encoding="utf-8")
         ]
     )
     

--- a/backend/desktop_main.py
+++ b/backend/desktop_main.py
@@ -60,7 +60,7 @@ class DesktopServiceManager:
             level=getattr(logging, self.config.log_level.upper()),
             format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
             handlers=[
-                logging.FileHandler(self.config.paths.data_dir / "logs" / "autoclip.log"),
+                logging.FileHandler(self.config.paths.data_dir / "logs" / "autoclip.log", encoding="utf-8"),
                 logging.StreamHandler()
             ]
         )


### PR DESCRIPTION
## Summary
Both `app_factory.py` and `desktop_main.py` open their log `FileHandler` without an explicit `encoding`, so Python falls back to `locale.getpreferredencoding()` for the file. On Windows that's the system codepage (e.g. cp1252), not UTF-8 — and this codebase's log messages are written in Chinese. Every single Chinese log line raises an encode failure inside the logging module itself:

```
UnicodeEncodeError: 'charmap' codec can't encode characters in position
N-M: character maps to <undefined>
```

`logging.Handler.handleError()` catches this per-record rather than crashing the app, so the practical effect is a full Python traceback dumped to stderr for every single log call containing non-ASCII text — which on this codebase is most of them. Very noisy, and easy to miss a real error in the flood.

Passing `encoding="utf-8"` explicitly to both `FileHandler`s fixes it.

## Test plan
- [x] Reproduced on Windows: ran the backend, confirmed the log file crashed on every Chinese log line with the traceback above.
- [x] Applied the fix, confirmed the same log lines write cleanly with no errors.

https://claude.ai/code/session_01UhcqhMkK2bg9c7h8t7rY95