### PR TITLE
feat: add a Windows dev-mode launcher (no Rust/Tauri toolchain required)

### DIFF
--- a/AutoClip.vbs
+++ b/AutoClip.vbs
@@ -1,0 +1,10 @@
+' Double-click launcher: starts AutoClip and opens it in an app window,
+' with no visible console/terminal.
+Dim fso, scriptDir, ps1Path
+Set fso = CreateObject("Scripting.FileSystemObject")
+scriptDir = fso.GetParentFolderName(WScript.ScriptFullName)
+ps1Path = scriptDir & "\scripts\windows_launcher.ps1"
+
+CreateObject("WScript.Shell").Run _
+    "powershell.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File """ & ps1Path & """", _
+    0, False

--- a/scripts/windows_launcher.ps1
+++ b/scripts/windows_launcher.ps1
@@ -1,0 +1,111 @@
+# AutoClip Windows app-mode launcher.
+# Starts the backend + Celery worker + frontend dev server (only if not
+# already running), waits for backend/frontend to become healthy, then
+# opens the UI in a chromeless Edge "app" window so it looks/feels like a
+# standalone desktop app. On window close, stops whichever of
+# backend/worker/frontend this script started.
+
+$ErrorActionPreference = 'Stop'
+
+$root = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
+Set-Location $root
+
+$logsDir = Join-Path $root 'logs'
+New-Item -ItemType Directory -Force -Path $logsDir | Out-Null
+
+# Defensively make sure ffmpeg is on PATH for this process tree even if the
+# process that launched us (e.g. a not-yet-refreshed Explorer session) is
+# still carrying a PATH from before ffmpeg was installed.
+$ffmpegBin = Get-ChildItem -Path (Join-Path $env:LOCALAPPDATA 'Microsoft\WinGet\Packages') `
+    -Filter 'ffmpeg.exe' -Recurse -ErrorAction SilentlyContinue |
+    Select-Object -First 1 -ExpandProperty DirectoryName
+if ($ffmpegBin -and ($env:Path -notlike "*$ffmpegBin*")) {
+    $env:Path = "$ffmpegBin;$env:Path"
+}
+
+function Test-Port([int]$port) {
+    try {
+        $client = New-Object System.Net.Sockets.TcpClient
+        $async = $client.BeginConnect('127.0.0.1', $port, $null, $null)
+        $ok = $async.AsyncWaitHandle.WaitOne(300)
+        if ($ok -and $client.Connected) { $client.Close(); return $true }
+        $client.Close()
+        return $false
+    } catch {
+        return $false
+    }
+}
+
+function Wait-Port([int]$port, [int]$timeoutSeconds) {
+    $deadline = (Get-Date).AddSeconds($timeoutSeconds)
+    while ((Get-Date) -lt $deadline) {
+        if (Test-Port $port) { return $true }
+        Start-Sleep -Milliseconds 400
+    }
+    return $false
+}
+
+$backendProc = $null
+$celeryProc = $null
+$frontendProc = $null
+
+$venvPython = Join-Path $root 'venv\Scripts\python.exe'
+$env:PYTHONIOENCODING = 'utf-8'
+$env:PYTHONPATH = $root
+
+# --- Backend (FastAPI/uvicorn on :8000) ---
+if (-not (Test-Port 8000)) {
+    $backendProc = Start-Process -FilePath $venvPython `
+        -ArgumentList '-m', 'uvicorn', 'backend.main:app', '--port', '8000' `
+        -WorkingDirectory $root -WindowStyle Hidden -PassThru `
+        -RedirectStandardOutput (Join-Path $logsDir 'backend.out.log') `
+        -RedirectStandardError (Join-Path $logsDir 'backend.err.log')
+}
+Wait-Port 8000 30 | Out-Null
+
+# --- Celery worker (consumes the video-processing task queue; without this
+#     nothing ever actually processes, it just sits queued forever) ---
+$celeryRunning = Get-CimInstance Win32_Process -Filter "Name = 'python.exe'" -ErrorAction SilentlyContinue |
+    Where-Object { $_.CommandLine -match 'celery' -and $_.CommandLine -match 'worker' }
+if (-not $celeryRunning) {
+    $celeryProc = Start-Process -FilePath $venvPython `
+        -ArgumentList '-m', 'celery', '-A', 'backend.celery_app', 'worker', `
+            '--loglevel=info', '--pool=solo', `
+            '-Q', 'celery,processing,video,notification,maintenance,upload' `
+        -WorkingDirectory $root -WindowStyle Hidden -PassThru `
+        -RedirectStandardOutput (Join-Path $logsDir 'celery.out.log') `
+        -RedirectStandardError (Join-Path $logsDir 'celery.err.log')
+}
+
+# --- Frontend (Vite dev server on :3000, proxies /api to :8000) ---
+if (-not (Test-Port 3000)) {
+    $frontendDir = Join-Path $root 'frontend'
+    $npmCmd = (Get-Command npm.cmd -ErrorAction SilentlyContinue).Source
+    if (-not $npmCmd) { $npmCmd = 'npm.cmd' }
+    $frontendProc = Start-Process -FilePath $npmCmd -ArgumentList 'run', 'dev' `
+        -WorkingDirectory $frontendDir -WindowStyle Hidden -PassThru `
+        -RedirectStandardOutput (Join-Path $logsDir 'frontend.out.log') `
+        -RedirectStandardError (Join-Path $logsDir 'frontend.err.log')
+}
+Wait-Port 3000 30 | Out-Null
+
+# --- App window (isolated profile so it opens as its own process, not a tab
+#     in whatever Edge window the user already has open) ---
+$edge = 'C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe'
+if (-not (Test-Path $edge)) {
+    $edge = 'C:\Program Files\Microsoft\Edge\Application\msedge.exe'
+}
+$profileDir = Join-Path $env:LOCALAPPDATA 'AutoClipAppWindow'
+
+Start-Process -FilePath $edge -ArgumentList `
+    "--app=http://localhost:3000", `
+    "--user-data-dir=$profileDir", `
+    "--window-size=1280,860" `
+    -Wait
+
+# --- Cleanup: only stop what we started ---
+foreach ($proc in @($backendProc, $celeryProc, $frontendProc)) {
+    if ($proc -and -not $proc.HasExited) {
+        try { Start-Process -FilePath 'taskkill.exe' -ArgumentList '/F', '/T', '/PID', $proc.Id -WindowStyle Hidden -Wait } catch {}
+    }
+}


### PR DESCRIPTION
## Summary
The repo's only packaged desktop build path (`BUILD_GUIDE.md`, `scripts/build_macos_arm.sh`) is macOS Apple Silicon only, and even that needs the Rust/cargo-tauri toolchain. There's currently no way to run AutoClip as anything other than "open two terminals and run uvicorn + npm run dev by hand" on Windows.

This adds an **optional, purely additive** dev-mode launcher for people who already have the project set up per `STARTUP_GUIDE.md` (venv + `npm install` done) and want something closer to double-clicking an app rather than manually juggling terminals:

- **`AutoClip.vbs`** — a silent double-click entry point (no visible console window).
- **`scripts/windows_launcher.ps1`** — starts the backend (uvicorn), a Celery worker (routed to the queues `backend/celery_app.py` actually uses — without a worker consuming the queue, nothing ever processes, it just sits queued forever, which I only discovered by testing this), and the frontend dev server, each only if not already running. Once healthy, opens the UI in a chromeless Edge "app" window (isolated profile, so it gets its own window/taskbar entry rather than opening a tab in whatever Edge window the user already has open) instead of a bare browser tab. On window close, stops whichever of the three it started (leaves anything the user started manually alone).

**This is dev-mode only** — still needs Python/Node/ffmpeg set up locally, same as running the pieces by hand. It's not a substitute for a real packaged Windows installer, which would need its own PBS-style bundling work analogous to `build_macos_arm.sh`. This just makes the existing dev-mode workflow one double-click instead of two terminals.

Two new files, nothing existing is touched — safe to close if this isn't something you want in the repo.

## Test plan
- [x] Ran end-to-end on Windows: double-click → backend/Celery/frontend spin up in the background (no visible console) → app window opens with no browser chrome (clean page title, no tab bar) → closing the window tears down the three processes it started, confirmed via port checks.
- [x] Confirmed it doesn't interfere with (or duplicate) already-running instances of backend/Celery/frontend.
- [x] Actually processed a real YouTube video end-to-end through it (download → Whisper transcription → full AI clipping pipeline) to confirm the Celery worker addition is what was missing for real usage.

https://claude.ai/code/session_01UhcqhMkK2bg9c7h8t7rY95