### PR TITLE
fix(frontend): clear the six NodeJS.Timeout typecheck errors and make typecheck blocking in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,6 @@ jobs:
         run: npm run lint
 
       - name: Typecheck
-        continue-on-error: true
         run: npm run typecheck
 
       - name: Build

--- a/frontend/src/components/AccountHealthMonitor.tsx
+++ b/frontend/src/components/AccountHealthMonitor.tsx
@@ -358,7 +358,7 @@ const AccountHealthMonitor: React.FC<AccountHealthMonitorProps> = () => {
   // 自动刷新
   useEffect(() => {
     if (autoRefresh) {
-      const interval = setInterval(() => {
+      const interval = window.setInterval(() => {
         fetchHealthSummary();
       }, 60000); // 每分钟刷新一次
       setRefreshInterval(interval);

--- a/frontend/src/components/BilibiliAccountManager.tsx
+++ b/frontend/src/components/BilibiliAccountManager.tsx
@@ -174,7 +174,7 @@ const BilibiliAccountManager: React.FC = () => {
       let pollCount = 0
       const maxPolls = 60
       
-      const interval = setInterval(async () => {
+      const interval = window.setInterval(async () => {
         try {
           pollCount++
           if (pollCount > maxPolls) {

--- a/frontend/src/components/BilibiliDownload.tsx
+++ b/frontend/src/components/BilibiliDownload.tsx
@@ -148,7 +148,7 @@ const BilibiliDownload: React.FC<BilibiliDownloadProps> = ({ onDownloadSuccess }
   }
 
   const startPolling = (taskId: string, videoType: 'bilibili' | 'youtube') => {
-    const interval = setInterval(async () => {
+    const interval = window.setInterval(async () => {
       try {
         let task
         if (videoType === 'bilibili') {

--- a/frontend/src/hooks/useProjectPolling.ts
+++ b/frontend/src/hooks/useProjectPolling.ts
@@ -62,7 +62,7 @@ export const useProjectPolling = ({
     poll()
     
     // 设置定时器
-    intervalRef.current = setInterval(poll, interval)
+    intervalRef.current = window.setInterval(poll, interval)
   }
 
   const stopPolling = () => {

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -217,7 +217,7 @@ export const useWebSocket = (options: UseWebSocketOptions) => {
           const delay = Math.min(2000 * Math.pow(2, reconnectAttempts), 15000);
           console.log(`将在 ${delay}ms 后尝试重连 (${reconnectAttempts}/${maxReconnectAttempts})`);
           
-          reconnectTimeoutRef = setTimeout(() => {
+          reconnectTimeoutRef = window.setTimeout(() => {
             ensureConnected();
           }, delay);
         } else if (reconnectAttempts >= maxReconnectAttempts) {

--- a/frontend/src/stores/useSimpleProgressStore.ts
+++ b/frontend/src/stores/useSimpleProgressStore.ts
@@ -114,7 +114,7 @@ export const useSimpleProgressStore = create<SimpleProgressState>((set, get) => 
       fetchSnapshots()
 
       // 设置定时器
-      timer = setInterval(fetchSnapshots, intervalMs)
+      timer = window.setInterval(fetchSnapshots, intervalMs)
 
       set({
         isPolling: true,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 内容

`npm run typecheck` 在 `main` 上一直有 6 个错误（#78 作者也提到过），CI 里靠 `continue-on-error: true` 放行：

```
AccountHealthMonitor.tsx(364)  BilibiliAccountManager.tsx(210)  BilibiliDownload.tsx(185)
useProjectPolling.ts(65)       useWebSocket.ts(220)             useSimpleProgressStore.ts(117)
```

都是同一类问题：`setInterval` / `setTimeout` 在当前 tsconfig 下解析到 Node 的 `Timeout` 类型，而存放它的 state / ref 是 `number`。改为 `window.setInterval` / `window.setTimeout`，命中浏览器重载（返回 `number`），6 处各改一行。

typecheck 干净后，把 CI 里的 `continue-on-error` 去掉，让类型错误从此阻断。

## 验证

- `npm run typecheck`：0 错误
- `npm run lint`：通过

## 说明

独立于 #89（v1.2.1 止血），两者不冲突，可任意顺序合并。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a076e0-b655-7492-b632-bb1d09bb85bc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a076e0-b655-7492-b632-bb1d09bb85bc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

