### PR TITLE
feat(llm): custom base_url for OpenAI-compatible endpoints + persist provider choice

### DIFF
--- a/backend/api/v1/settings.py
+++ b/backend/api/v1/settings.py
@@ -61,6 +61,8 @@ class ApiKeys(BaseModel):
 class ApiSettings(BaseModel):
     """API设置"""
     api_keys: ApiKeys = Field(default_factory=ApiKeys, description="API密钥")
+    api_provider: str = Field(default="dashscope", description="当前 LLM 提供商（dashscope / openai / gemini / siliconflow）")
+    api_base_url: str = Field(default="", description="OpenAI 兼容接口地址；仅 provider=openai 生效，空为官方地址")
     api_model: str = Field(default="qwen-plus", description="默认模型")
     api_max_tokens: int = Field(default=4096, description="最大Token数")
     api_timeout: int = Field(default=30, description="API超时时间(秒)")
@@ -301,7 +303,9 @@ async def clear_settings(
 
 class TestApiRequest(BaseModel):
     provider: str
-    api_key: str
+    api_key: str = ""
+    base_url: Optional[str] = None   # 仅 openai：兼容接口地址
+    model: Optional[str] = None      # 用哪个模型发测试请求（兼容接口必须是服务端真有的模型名）
 
 @router.post("/test-api")
 async def test_api_connection(request: TestApiRequest):
@@ -309,36 +313,41 @@ async def test_api_connection(request: TestApiRequest):
     check_desktop_mode()
     
     try:
-        # 首先进行基本的API Key格式验证
-        if not request.api_key or len(request.api_key.strip()) < 10:
-            return {
-                "success": False,
-                "error": "API Key为空或过短，请检查输入",
-                "provider": request.provider
-            }
-        
-        # 根据提供商进行格式验证
-        if request.provider in ["dashscope", "openai"]:
-            if not request.api_key.startswith("sk-"):
+        from backend.core.llm_providers import normalize_base_url, OPENAI_OFFICIAL_BASE_URL
+        custom_base_url = normalize_base_url(request.base_url) if request.provider == "openai" else ""
+        if custom_base_url == OPENAI_OFFICIAL_BASE_URL:
+            custom_base_url = ""
+
+        # 官方服务才做 key 格式校验；自建 OpenAI 兼容服务（Ollama / vLLM 等）常常不需要 key
+        if not custom_base_url:
+            if not request.api_key or len(request.api_key.strip()) < 10:
+                return {
+                    "success": False,
+                    "error": "API Key为空或过短，请检查输入",
+                    "provider": request.provider
+                }
+            if request.provider in ["dashscope", "openai"] and not request.api_key.startswith("sk-"):
                 return {
                     "success": False,
                     "error": f"{request.provider} API Key格式可能不正确，通常以'sk-'开头",
                     "provider": request.provider
                 }
+
+        model_kwargs = {"model_name": request.model} if request.model else {}
         
         # 根据提供商测试API连接
         if request.provider == "dashscope":
             from backend.core.llm_providers import DashScopeProvider
-            provider_instance = DashScopeProvider(api_key=request.api_key)
+            provider_instance = DashScopeProvider(api_key=request.api_key, **model_kwargs)
         elif request.provider == "openai":
             from backend.core.llm_providers import OpenAIProvider
-            provider_instance = OpenAIProvider(api_key=request.api_key)
+            provider_instance = OpenAIProvider(api_key=request.api_key, base_url=custom_base_url or None, **model_kwargs)
         elif request.provider == "gemini":
             from backend.core.llm_providers import GeminiProvider
-            provider_instance = GeminiProvider(api_key=request.api_key)
+            provider_instance = GeminiProvider(api_key=request.api_key, **model_kwargs)
         elif request.provider == "siliconflow":
             from backend.core.llm_providers import SiliconFlowProvider
-            provider_instance = SiliconFlowProvider(api_key=request.api_key)
+            provider_instance = SiliconFlowProvider(api_key=request.api_key, **model_kwargs)
         else:
             raise HTTPException(status_code=400, detail="不支持的API提供商")
         
@@ -356,6 +365,8 @@ async def test_api_connection(request: TestApiRequest):
             error_msg = f"API连接测试失败"
             if request.provider == "dashscope":
                 error_msg += "。请检查API Key是否正确，DashScope API Key通常以'sk-'开头"
+            elif request.provider == "openai" and custom_base_url:
+                error_msg += f"。请检查接口地址 {custom_base_url} 是否可达、模型名是否存在，以及该服务是否需要 API Key"
             elif request.provider == "openai":
                 error_msg += "。请检查API Key是否正确，OpenAI API Key通常以'sk-'开头"
             elif request.provider == "gemini":
@@ -413,6 +424,13 @@ async def update_settings(settings: DesktopSettings):
         settings_file = config.paths.data_dir / "settings.json"
         with open(settings_file, 'w', encoding='utf-8') as f:
             json.dump(settings.dict(), f, indent=2, ensure_ascii=False)
+
+        # 让本进程的 LLM 管理器立刻切到新 provider / base_url / 模型（worker 进程靠 mtime 自动重载）
+        try:
+            from backend.core.llm_manager import get_llm_manager
+            get_llm_manager()._reload_if_settings_changed()
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"刷新 LLM 管理器失败（下次调用时会自动重载）: {e}")
         
         # 重要：保存主配置文件，确保API key等关键配置被持久化
         from backend.core.desktop_config import save_desktop_config
@@ -658,16 +676,20 @@ async def get_current_provider():
     check_desktop_mode()
     
     try:
-        config = get_desktop_config()
-        
-        # 根据当前配置返回提供商信息
+        # 以 LLM 管理器的实际状态为准（它读的就是设置页保存的 settings.json），
+        # 而不是固定返回 dashscope——那会让设置页每次打开都"跳回"通义千问。
+        from backend.core.llm_manager import get_llm_manager
+        info = get_llm_manager().get_current_provider_info()
+        display_name = info.get("display_name") or info.get("provider") or "阿里通义千问"
         provider_info = {
-            "provider": "dashscope",  # 默认提供商
-            "model": config.default_model or "qwen-plus",
-            "available": True,
-            "display_name": "通义千问",
-            "description": "阿里云通义千问服务"
+            "provider": info.get("provider") or "dashscope",
+            "model": info.get("model") or "qwen-plus",
+            "available": bool(info.get("available")),
+            "display_name": display_name,
+            "description": f"{display_name} 模型服务",
         }
+        if info.get("base_url"):
+            provider_info["base_url"] = info["base_url"]
         
         return provider_info
         

--- a/backend/core/llm_manager.py
+++ b/backend/core/llm_manager.py
@@ -24,8 +24,24 @@ class LLMManager:
         
         self.settings_file = settings_file or self._get_default_settings_file()
         self.current_provider: Optional[LLMProvider] = None
+        self._settings_mtime: Optional[float] = None
         self.settings = self._load_settings()
         self._initialize_provider()
+
+    def _current_settings_mtime(self) -> Optional[float]:
+        try:
+            return self.settings_file.stat().st_mtime
+        except OSError:
+            return None
+
+    def _reload_if_settings_changed(self) -> None:
+        """设置页保存后 settings.json 会变；API 进程与 Celery worker 都要在下一次调用时拿到新配置，
+        而不是等重启。"""
+        mtime = self._current_settings_mtime()
+        if mtime != self._settings_mtime:
+            logger.info("检测到 settings.json 变化，重新加载 LLM 配置")
+            self.settings = self._load_settings()
+            self._initialize_provider()
     
     def _get_default_settings_file(self) -> Path:
         """获取默认设置文件路径"""
@@ -33,6 +49,14 @@ class LLMManager:
         app_dir = os.getenv("AUTOCLIP_APP_DIR")
         if app_dir:
             return Path(app_dir) / "settings.json"
+
+        # 与设置 API 写入的位置保持同一来源（path_utils.get_data_directory），
+        # 否则设置页保存到 A、这里读 B，切换 provider 永远不生效
+        try:
+            from .path_utils import get_data_directory
+            return get_data_directory() / "settings.json"
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"无法通过 path_utils 定位 settings.json，回退到旧逻辑: {e}")
         
         # 优先使用默认的用户目录（macOS）- 客户端配置位置
         default_app_dir = Path.home() / "Library" / "Application Support" / "AutoClip"
@@ -67,6 +91,8 @@ class LLMManager:
             "llm_provider": "dashscope",
             "dashscope_api_key": "",
             "openai_api_key": "",
+            # OpenAI 兼容接口地址；空 = 官方。环境变量 OPENAI_BASE_URL 作为兜底
+            "openai_base_url": os.getenv("OPENAI_BASE_URL", ""),
             "gemini_api_key": "",
             "siliconflow_api_key": "",
             "model_name": "qwen-plus",
@@ -75,6 +101,7 @@ class LLMManager:
             "max_clips_per_collection": 5
         }
         
+        self._settings_mtime = self._current_settings_mtime()
         if self.settings_file.exists():
             try:
                 with open(self.settings_file, 'r', encoding='utf-8') as f:
@@ -82,14 +109,20 @@ class LLMManager:
                     
                     # 处理新的配置格式（客户端配置）
                     if "api" in saved_settings and "api_keys" in saved_settings["api"]:
-                        api_keys = saved_settings["api"]["api_keys"]
+                        api = saved_settings["api"]
+                        api_keys = api["api_keys"]
                         default_settings.update({
                             "dashscope_api_key": api_keys.get("dashscope", ""),
                             "openai_api_key": api_keys.get("openai", ""),
                             "gemini_api_key": api_keys.get("gemini", ""),
                             "siliconflow_api_key": api_keys.get("siliconflow", ""),
-                            "model_name": saved_settings["api"].get("api_model", "qwen-plus")
+                            "model_name": api.get("api_model", "qwen-plus")
                         })
+                        # 设置页保存的提供商；旧版 settings.json 没有这个字段，保持 dashscope
+                        if api.get("api_provider"):
+                            default_settings["llm_provider"] = api["api_provider"]
+                        if api.get("api_base_url"):
+                            default_settings["openai_base_url"] = api["api_base_url"]
                     else:
                         # 处理旧的配置格式（直接平铺）
                         default_settings.update(saved_settings)
@@ -97,7 +130,48 @@ class LLMManager:
             except Exception as e:
                 logger.warning(f"加载设置文件失败: {e}")
         
+        self._apply_env_fallbacks(default_settings)
         return default_settings
+
+    # Docker / 本地脚本模式没有设置页可用，只能靠环境变量（env.example 里也是这么写的），
+    # 但此前这里只读 settings.json，导致 API_DASHSCOPE_API_KEY 等变量形同虚设。
+    _ENV_KEY_FALLBACKS = {
+        "dashscope_api_key": ("API_DASHSCOPE_API_KEY", "DASHSCOPE_API_KEY"),
+        "openai_api_key": ("API_OPENAI_API_KEY", "OPENAI_API_KEY"),
+        "gemini_api_key": ("API_GEMINI_API_KEY", "GEMINI_API_KEY"),
+        "siliconflow_api_key": ("API_SILICONFLOW_API_KEY", "SILICONFLOW_API_KEY"),
+    }
+
+    def _apply_env_fallbacks(self, settings: Dict[str, Any]) -> None:
+        for setting_name, env_names in self._ENV_KEY_FALLBACKS.items():
+            if settings.get(setting_name):
+                continue
+            for env_name in env_names:
+                value = os.getenv(env_name, "").strip()
+                if value:
+                    settings[setting_name] = value
+                    break
+
+        # 只有 settings.json 没有明确指定提供商/模型时，才让环境变量决定
+        file_has_provider = self._file_specifies("api_provider", "llm_provider")
+        env_provider = os.getenv("LLM_PROVIDER", "").strip().lower()
+        if env_provider and not file_has_provider:
+            settings["llm_provider"] = env_provider
+        env_model = os.getenv("API_MODEL_NAME", "").strip() or os.getenv("LLM_MODEL", "").strip()
+        if env_model and not self._file_specifies("api_model", "model_name"):
+            settings["model_name"] = env_model
+
+    def _file_specifies(self, *field_names: str) -> bool:
+        """settings.json（客户端嵌套格式或旧平铺格式）里是否显式写了某个字段"""
+        try:
+            if not self.settings_file.exists():
+                return False
+            with open(self.settings_file, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+        except Exception:
+            return False
+        api = data.get("api", {}) if isinstance(data, dict) else {}
+        return any(bool(api.get(name)) or bool(data.get(name)) for name in field_names)
     
     def _save_settings(self):
         """保存设置"""
@@ -117,19 +191,30 @@ class LLMManager:
             
             # 获取对应提供商的API密钥
             api_key = self._get_api_key_for_provider(provider_type)
-            
-            
-            if api_key:
+            provider_kwargs = self._get_provider_kwargs(provider_type)
+
+            # 自建 OpenAI 兼容服务（Ollama / vLLM 等）常常不需要 key，有 base_url 就够
+            if api_key or (provider_type == ProviderType.OPENAI and provider_kwargs.get("base_url")):
                 self.current_provider = LLMProviderFactory.create_provider(
-                    provider_type, api_key, model_name
+                    provider_type, api_key or "", model_name, **provider_kwargs
                 )
-                logger.info(f"已初始化{provider_type.value}提供商，模型: {model_name}")
+                logger.info(f"已初始化{provider_type.value}提供商，模型: {model_name}"
+                            + (f", base_url: {provider_kwargs['base_url']}" if provider_kwargs.get("base_url") else ""))
             else:
                 logger.warning(f"未找到{provider_type.value}的API密钥")
+                self.current_provider = None
                 
         except Exception as e:
             logger.error(f"初始化提供商失败: {e}")
             self.current_provider = None
+
+    def _get_provider_kwargs(self, provider_type: ProviderType) -> Dict[str, Any]:
+        """提供商构造参数（目前只有 OpenAI 兼容接口的 base_url）"""
+        if provider_type == ProviderType.OPENAI:
+            base_url = (self.settings.get("openai_base_url") or "").strip()
+            if base_url:
+                return {"base_url": base_url}
+        return {}
     
     def _get_api_key_for_provider(self, provider_type: ProviderType) -> Optional[str]:
         """获取指定提供商的API密钥"""
@@ -151,7 +236,8 @@ class LLMManager:
         self._save_settings()
         self._initialize_provider()
     
-    def set_provider(self, provider_type: ProviderType, api_key: str, model_name: str):
+    def set_provider(self, provider_type: ProviderType, api_key: str, model_name: str,
+                     base_url: Optional[str] = None):
         """设置提供商"""
         try:
             # 更新设置
@@ -171,13 +257,11 @@ class LLMManager:
             key_name = key_mapping.get(provider_type)
             if key_name:
                 provider_settings[key_name] = api_key
-            
+            if provider_type == ProviderType.OPENAI and base_url is not None:
+                provider_settings["openai_base_url"] = base_url
+
+            # update_settings 会保存并重新初始化 current_provider
             self.update_settings(provider_settings)
-            
-            # 创建新的提供商实例
-            self.current_provider = LLMProviderFactory.create_provider(
-                provider_type, api_key, model_name
-            )
             
             logger.info(f"已切换到{provider_type.value}提供商，模型: {model_name}")
             
@@ -187,6 +271,7 @@ class LLMManager:
     
     def call(self, prompt: str, input_data: Any = None, **kwargs) -> str:
         """调用LLM"""
+        self._reload_if_settings_changed()
         if not self.current_provider:
             raise ValueError("未配置LLM提供商，请在设置页面配置API密钥")
         
@@ -213,10 +298,11 @@ class LLMManager:
                 time.sleep(2 ** attempt)  # 指数退避
         return ""
     
-    def test_provider_connection(self, provider_type: ProviderType, api_key: str, model_name: str) -> bool:
+    def test_provider_connection(self, provider_type: ProviderType, api_key: str, model_name: str,
+                                 **provider_kwargs) -> bool:
         """测试提供商连接"""
         try:
-            provider = LLMProviderFactory.create_provider(provider_type, api_key, model_name)
+            provider = LLMProviderFactory.create_provider(provider_type, api_key, model_name, **provider_kwargs)
             return provider.test_connection()
         except Exception as e:
             logger.error(f"测试{provider_type.value}连接失败: {e}")
@@ -224,24 +310,29 @@ class LLMManager:
     
     def get_current_provider_info(self) -> Dict[str, Any]:
         """获取当前提供商信息"""
-        if not self.current_provider:
-            return {"provider": None, "model": None, "available": False}
-        
-        provider_type = ProviderType(self.settings.get("llm_provider", "dashscope"))
+        self._reload_if_settings_changed()
+        provider_value = self.settings.get("llm_provider", "dashscope")
+        try:
+            provider_type = ProviderType(provider_value)
+        except ValueError:
+            return {"provider": provider_value, "model": None, "available": False}
         model_name = self.settings.get("model_name", "qwen-plus")
-        
-        return {
+        info = {
             "provider": provider_type.value,
             "model": model_name,
-            "available": True,
-            "display_name": self._get_provider_display_name(provider_type)
+            "available": self.current_provider is not None,
+            "display_name": self._get_provider_display_name(provider_type),
         }
+        base_url = self._get_provider_kwargs(provider_type).get("base_url")
+        if base_url:
+            info["base_url"] = base_url
+        return info
     
     def _get_provider_display_name(self, provider_type: ProviderType) -> str:
         """获取提供商显示名称"""
         display_names = {
             ProviderType.DASHSCOPE: "阿里通义千问",
-            ProviderType.OPENAI: "OpenAI",
+            ProviderType.OPENAI: "OpenAI / 兼容接口",
             ProviderType.GEMINI: "Google Gemini",
             ProviderType.SILICONFLOW: "硅基流动"
         }

--- a/backend/core/llm_providers.py
+++ b/backend/core/llm_providers.py
@@ -240,14 +240,35 @@ class DashScopeProvider(LLMProvider):
             )
         ]
 
+OPENAI_OFFICIAL_BASE_URL = "https://api.openai.com/v1"
+# 本地/自建 OpenAI 兼容服务（Ollama、vLLM、LM Studio 等）通常不校验 key，但 SDK 要求非空
+OPENAI_COMPATIBLE_PLACEHOLDER_KEY = "EMPTY"
+
+
+def normalize_base_url(base_url: Optional[str]) -> str:
+    """去掉空白与结尾的 `/`，空值返回空串（表示使用官方地址）"""
+    return (base_url or "").strip().rstrip("/")
+
+
 class OpenAIProvider(LLMProvider):
-    """OpenAI提供商"""
+    """OpenAI 及一切 OpenAI 兼容接口（智谱、DeepSeek、OpenRouter、Ollama、vLLM、LM Studio 等）
+
+    通过 `base_url` 指向兼容服务即可复用；为空时走 OpenAI 官方地址。
+    """
     
-    def __init__(self, api_key: str, model_name: str = "gpt-3.5-turbo", **kwargs):
+    def __init__(self, api_key: str, model_name: str = "gpt-4o-mini", **kwargs):
         super().__init__(api_key, model_name, **kwargs)
+        self.base_url = normalize_base_url(kwargs.get("base_url") or os.getenv("OPENAI_BASE_URL"))
+        self.is_custom_endpoint = bool(self.base_url) and self.base_url != OPENAI_OFFICIAL_BASE_URL
+        if not api_key and self.is_custom_endpoint:
+            api_key = OPENAI_COMPATIBLE_PLACEHOLDER_KEY
+            self.api_key = api_key
         try:
             import openai
-            self.client = openai.OpenAI(api_key=api_key)
+            client_kwargs = {"api_key": api_key}
+            if self.base_url:
+                client_kwargs["base_url"] = self.base_url
+            self.client = openai.OpenAI(**client_kwargs)
         except ImportError:
             raise ImportError("请安装openai: pip install openai")
     
@@ -281,40 +302,39 @@ class OpenAIProvider(LLMProvider):
             raise
     
     def test_connection(self) -> bool:
-        """测试OpenAI连接"""
+        """测试OpenAI / 兼容接口连接"""
         try:
-            # 验证API Key格式
-            if not self.api_key or len(self.api_key.strip()) < 10:
-                logger.error("OpenAI API Key为空或过短")
-                return False
-            
-            # 检查API Key格式（OpenAI API Key通常是sk-开头）
-            if not self.api_key.startswith("sk-"):
-                logger.warning(f"OpenAI API Key格式可能不正确，期望以'sk-'开头，实际: {self.api_key[:10]}...")
+            # 官方 OpenAI 才校验 key 格式；兼容服务的 key 五花八门（甚至不需要）
+            if not self.is_custom_endpoint:
+                if not self.api_key or len(self.api_key.strip()) < 10:
+                    logger.error("OpenAI API Key为空或过短")
+                    return False
+                if not self.api_key.startswith("sk-"):
+                    logger.warning(f"OpenAI API Key格式可能不正确，期望以'sk-'开头，实际: {self.api_key[:10]}...")
             
             # 使用最简单的测试
             response = self.call("测试", max_tokens=1)
             return response and response.content is not None
         except Exception as e:
-            logger.error(f"OpenAI连接测试失败: {e}")
+            logger.error(f"OpenAI连接测试失败 (base_url={self.base_url or OPENAI_OFFICIAL_BASE_URL}): {e}")
             return False
     
     def get_available_models(self) -> List[ModelInfo]:
-        """获取OpenAI可用模型"""
+        """获取OpenAI可用模型（兼容接口的模型名由用户自行填写，这里只列官方常用型号）"""
         return [
             ModelInfo(
-                name="gpt-3.5-turbo",
-                display_name="GPT-3.5 Turbo",
+                name="gpt-4o-mini",
+                display_name="GPT-4o mini",
                 provider=ProviderType.OPENAI,
-                max_tokens=4096,
-                description="OpenAI GPT-3.5 Turbo模型"
+                max_tokens=128000,
+                description="OpenAI GPT-4o mini（性价比）"
             ),
             ModelInfo(
-                name="gpt-4",
-                display_name="GPT-4",
+                name="gpt-4o",
+                display_name="GPT-4o",
                 provider=ProviderType.OPENAI,
-                max_tokens=8192,
-                description="OpenAI GPT-4模型"
+                max_tokens=128000,
+                description="OpenAI GPT-4o"
             ),
             ModelInfo(
                 name="gpt-4-turbo",

--- a/backend/tests/test_llm_provider_config.py
+++ b/backend/tests/test_llm_provider_config.py
@@ -1,0 +1,221 @@
+"""OpenAI 兼容接口（自定义 base_url）与 provider 持久化 / 热重载的回归测试"""
+import asyncio
+import json
+import os
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+
+class _FakeOpenAIClient:
+    created = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        _FakeOpenAIClient.created.append(kwargs)
+
+
+@pytest.fixture
+def fake_openai(monkeypatch):
+    module = types.ModuleType("openai")
+    module.OpenAI = _FakeOpenAIClient
+    monkeypatch.setitem(sys.modules, "openai", module)
+    _FakeOpenAIClient.created.clear()
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    return _FakeOpenAIClient
+
+
+def test_openai_provider_defaults_to_official_endpoint(fake_openai):
+    from backend.core.llm_providers import OpenAIProvider
+
+    provider = OpenAIProvider(api_key="sk-test", model_name="gpt-4o-mini")
+
+    assert provider.base_url == ""
+    assert provider.is_custom_endpoint is False
+    assert fake_openai.created[-1] == {"api_key": "sk-test"}
+
+
+def test_openai_provider_uses_custom_base_url_and_placeholder_key(fake_openai):
+    from backend.core.llm_providers import (
+        OPENAI_COMPATIBLE_PLACEHOLDER_KEY,
+        OpenAIProvider,
+    )
+
+    provider = OpenAIProvider(api_key="", model_name="qwen2.5:7b", base_url="http://localhost:11434/v1/")
+
+    assert provider.base_url == "http://localhost:11434/v1"
+    assert provider.is_custom_endpoint is True
+    assert fake_openai.created[-1] == {
+        "api_key": OPENAI_COMPATIBLE_PLACEHOLDER_KEY,
+        "base_url": "http://localhost:11434/v1",
+    }
+
+
+def test_openai_provider_reads_base_url_from_env(fake_openai, monkeypatch):
+    from backend.core.llm_providers import OpenAIProvider
+
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://open.bigmodel.cn/api/paas/v4")
+    provider = OpenAIProvider(api_key="zhipu-key-1234567890", model_name="glm-4-flash")
+
+    assert provider.base_url == "https://open.bigmodel.cn/api/paas/v4"
+    assert fake_openai.created[-1]["base_url"] == "https://open.bigmodel.cn/api/paas/v4"
+
+
+def test_official_endpoint_still_rejects_short_key(fake_openai):
+    from backend.core.llm_providers import OpenAIProvider
+
+    provider = OpenAIProvider(api_key="short", model_name="gpt-4o-mini")
+    assert provider.test_connection() is False
+
+
+def _write_client_settings(path: Path, **api_overrides):
+    api = {
+        "api_keys": {"dashscope": "", "openai": "", "gemini": "", "siliconflow": ""},
+        "api_model": "qwen-plus",
+    }
+    api.update(api_overrides)
+    path.write_text(json.dumps({"api": api}), encoding="utf-8")
+
+
+@pytest.fixture
+def manager_env(monkeypatch, tmp_path, fake_openai):
+    for name in ("LLM_PROVIDER", "API_MODEL_NAME", "LLM_MODEL", "API_OPENAI_API_KEY", "OPENAI_API_KEY",
+                 "API_DASHSCOPE_API_KEY", "DASHSCOPE_API_KEY"):
+        monkeypatch.delenv(name, raising=False)
+
+    # 不让配置同步服务碰真实用户目录
+    from backend.core import llm_manager as manager_module
+    monkeypatch.setattr(manager_module.config_sync_service, "is_sync_needed", lambda: False)
+    return tmp_path / "settings.json"
+
+
+def test_manager_honours_saved_provider_and_base_url(manager_env):
+    from backend.core.llm_manager import LLMManager
+
+    _write_client_settings(
+        manager_env,
+        api_provider="openai",
+        api_base_url="https://api.deepseek.com/v1",
+        api_model="deepseek-chat",
+        api_keys={"dashscope": "", "openai": "sk-deepseek-key", "gemini": "", "siliconflow": ""},
+    )
+    manager = LLMManager(settings_file=manager_env)
+
+    info = manager.get_current_provider_info()
+    assert info["provider"] == "openai"
+    assert info["model"] == "deepseek-chat"
+    assert info["base_url"] == "https://api.deepseek.com/v1"
+    assert info["available"] is True
+    assert manager.current_provider.base_url == "https://api.deepseek.com/v1"
+
+
+def test_manager_allows_keyless_custom_endpoint(manager_env):
+    from backend.core.llm_manager import LLMManager
+
+    _write_client_settings(manager_env, api_provider="openai", api_base_url="http://localhost:11434/v1",
+                           api_model="qwen2.5:7b")
+    manager = LLMManager(settings_file=manager_env)
+
+    assert manager.current_provider is not None
+    assert manager.current_provider.is_custom_endpoint is True
+
+
+def test_manager_reloads_when_settings_file_changes(manager_env):
+    from backend.core.llm_manager import LLMManager
+
+    _write_client_settings(manager_env)  # 没有 key -> 未配置
+    manager = LLMManager(settings_file=manager_env)
+    assert manager.get_current_provider_info()["available"] is False
+
+    _write_client_settings(manager_env, api_provider="openai", api_base_url="http://localhost:11434/v1",
+                           api_model="qwen2.5:7b")
+    # 同一秒内写两次 mtime 可能相同，强制改一下
+    os.utime(manager_env, (manager_env.stat().st_atime, manager_env.stat().st_mtime + 5))
+
+    info = manager.get_current_provider_info()
+    assert info["available"] is True
+    assert info["provider"] == "openai"
+    assert info["model"] == "qwen2.5:7b"
+
+
+def test_manager_env_fallbacks_for_docker(manager_env, monkeypatch):
+    from backend.core.llm_manager import LLMManager
+
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://open.bigmodel.cn/api/paas/v4")
+    monkeypatch.setenv("API_OPENAI_API_KEY", "zhipu-key-1234567890")
+    monkeypatch.setenv("API_MODEL_NAME", "glm-4-flash")
+
+    manager = LLMManager(settings_file=manager_env)  # 文件不存在
+
+    info = manager.get_current_provider_info()
+    assert info == {
+        "provider": "openai",
+        "model": "glm-4-flash",
+        "available": True,
+        "display_name": "OpenAI / 兼容接口",
+        "base_url": "https://open.bigmodel.cn/api/paas/v4",
+    }
+
+
+class _ChatCapableClient(_FakeOpenAIClient):
+    """带 chat.completions.create 的假客户端，记录请求模型名"""
+    last_model = None
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        outer = self
+
+        class _Completions:
+            def create(self, **params):
+                _ChatCapableClient.last_model = params["model"]
+                message = types.SimpleNamespace(content="ok")
+                choice = types.SimpleNamespace(message=message, finish_reason="stop")
+                return types.SimpleNamespace(choices=[choice], usage=None)
+
+        self.chat = types.SimpleNamespace(completions=_Completions())
+        self.outer = outer
+
+
+def test_test_api_endpoint_accepts_keyless_custom_endpoint(monkeypatch, fake_openai):
+    sys.modules["openai"].OpenAI = _ChatCapableClient
+    from backend.api.v1 import settings as settings_api
+
+    monkeypatch.setattr(settings_api, "check_desktop_mode", lambda relaxed=False: True)
+    request = settings_api.TestApiRequest(provider="openai", api_key="", base_url="http://localhost:11434/v1",
+                                          model="qwen2.5:7b")
+
+    result = asyncio.run(settings_api.test_api_connection(request))
+
+    assert result["success"] is True, result
+    assert _ChatCapableClient.created[-1]["base_url"] == "http://localhost:11434/v1"
+    assert _ChatCapableClient.last_model == "qwen2.5:7b"
+
+
+def test_test_api_endpoint_still_validates_official_key(monkeypatch, fake_openai):
+    from backend.api.v1 import settings as settings_api
+
+    monkeypatch.setattr(settings_api, "check_desktop_mode", lambda relaxed=False: True)
+    request = settings_api.TestApiRequest(provider="openai", api_key="short")
+
+    result = asyncio.run(settings_api.test_api_connection(request))
+
+    assert result["success"] is False
+    assert "过短" in result["error"]
+
+
+def test_settings_file_provider_wins_over_env(manager_env, monkeypatch):
+    from backend.core.llm_manager import LLMManager
+
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("API_MODEL_NAME", "glm-4-flash")
+    _write_client_settings(manager_env, api_provider="dashscope", api_model="qwen-max",
+                           api_keys={"dashscope": "", "openai": "", "gemini": "", "siliconflow": ""})
+
+    manager = LLMManager(settings_file=manager_env)
+    assert manager.settings["llm_provider"] == "dashscope"
+    assert manager.settings["model_name"] == "qwen-max"

--- a/env.example
+++ b/env.example
@@ -8,7 +8,17 @@ DATABASE_URL=sqlite:///./data/autoclip.db
 REDIS_URL=redis://localhost:6379/0
 
 # API配置
+# 桌面版在设置页配置即可；Docker / 脚本模式没有设置页时用下面的环境变量。
+# LLM_PROVIDER: dashscope | openai | gemini | siliconflow（settings.json 里已保存的提供商优先）
+LLM_PROVIDER=dashscope
 API_DASHSCOPE_API_KEY=your_dashscope_api_key_here
+# API_OPENAI_API_KEY=
+# API_GEMINI_API_KEY=
+# API_SILICONFLOW_API_KEY=
+# OpenAI 兼容接口地址（LLM_PROVIDER=openai 时生效，留空走 OpenAI 官方）。
+# 智谱: https://open.bigmodel.cn/api/paas/v4   DeepSeek: https://api.deepseek.com/v1
+# Ollama: http://localhost:11434/v1（Docker 内访问宿主机用 http://host.docker.internal:11434/v1）
+# OPENAI_BASE_URL=
 API_MODEL_NAME=qwen-plus
 API_MAX_TOKENS=4096
 API_TIMEOUT=30

--- a/frontend/src/hooks/useFirstRun.ts
+++ b/frontend/src/hooks/useFirstRun.ts
@@ -40,7 +40,9 @@ export const useFirstRun = () => {
           const hasApiKey = settings.api?.api_keys?.dashscope || 
                            settings.api?.api_keys?.openai ||
                            settings.api?.api_keys?.gemini ||
-                           settings.api?.api_keys?.siliconflow
+                           settings.api?.api_keys?.siliconflow ||
+                           // 本地 / 自建 OpenAI 兼容服务可以没有 key，只配接口地址
+                           (settings.api?.api_provider === 'openai' && settings.api?.api_base_url)
           
           console.log('🔑 API Key状态:', hasApiKey)
           

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -13,6 +13,15 @@ const { Content } = Layout
 const { Title, Text, Paragraph } = Typography
 const { TabPane } = Tabs
 
+const normalizeBaseUrl = (value: unknown): string =>
+  typeof value === 'string' ? value.trim().replace(/\/+$/, '') : ''
+
+// 模型选择框是 mode="tags" 的 Select，用户手动输入后拿到的是数组；后端只接受字符串
+const normalizeModelName = (value: unknown): string => {
+  if (Array.isArray(value)) return String(value[value.length - 1] ?? '').trim()
+  return typeof value === 'string' ? value.trim() : ''
+}
+
 const SettingsPage: React.FC = () => {
   const [form] = Form.useForm()
   const [loading, setLoading] = useState(false)
@@ -32,12 +41,12 @@ const SettingsPage: React.FC = () => {
       placeholder: '请输入通义千问API密钥'
     },
     openai: {
-      name: 'OpenAI',
+      name: 'OpenAI / 兼容接口',
       icon: <RobotOutlined />,
       color: '#52c41a',
-      description: 'OpenAI GPT系列模型',
+      description: 'OpenAI 及智谱、DeepSeek、Ollama 等兼容接口',
       apiKeyField: 'openai_api_key',
-      placeholder: '请输入OpenAI API密钥'
+      placeholder: '请输入 API 密钥（本地模型可留空）'
     },
     gemini: {
       name: 'Google Gemini',
@@ -91,7 +100,8 @@ const SettingsPage: React.FC = () => {
         const providerData = provider.status === 'fulfilled'
           ? provider.value
           : { available: false, provider: 'dashscope', display_name: '阿里通义千问', model: 'qwen-plus' }
-        const providerName = providerData.provider || 'dashscope'
+        // 以 settings.json 里保存的提供商为准；旧配置没有该字段时退回后端上报的当前提供商
+        const providerName = settingsData.api?.api_provider || providerData.provider || 'dashscope'
         setCurrentProvider(providerData)
         
         // 将嵌套的settings结构转换为扁平结构
@@ -99,6 +109,7 @@ const SettingsPage: React.FC = () => {
           llm_provider: providerName, // 使用实际的提供商
           dashscope_api_key: settingsData.api?.api_keys?.dashscope || '',
           openai_api_key: settingsData.api?.api_keys?.openai || '',
+          openai_base_url: settingsData.api?.api_base_url || '',
           gemini_api_key: settingsData.api?.api_keys?.gemini || '',
           siliconflow_api_key: settingsData.api?.api_keys?.siliconflow || '',
           jimeng_access_key: settingsData.api?.api_keys?.jimeng_access || '',
@@ -124,6 +135,7 @@ const SettingsPage: React.FC = () => {
           llm_provider: 'dashscope',
           dashscope_api_key: '',
           openai_api_key: '',
+          openai_base_url: '',
           gemini_api_key: '',
           siliconflow_api_key: '',
           jimeng_access_key: '',
@@ -199,7 +211,9 @@ const SettingsPage: React.FC = () => {
             jimeng_access: values.jimeng_access_key || existingApiKeys.jimeng_access || "",
             jimeng_secret: values.jimeng_secret_key || existingApiKeys.jimeng_secret || ""
           },
-          api_model: values.model_name || "qwen-plus",
+          api_provider: values.llm_provider || selectedProvider,
+          api_base_url: (values.llm_provider || selectedProvider) === 'openai' ? normalizeBaseUrl(values.openai_base_url) : '',
+          api_model: normalizeModelName(values.model_name) || "qwen-plus",
           api_max_tokens: 4096,
           api_timeout: 30
         },
@@ -242,16 +256,22 @@ const SettingsPage: React.FC = () => {
 
   // 测试API密钥
   const handleTestApiKey = async () => {
-    const apiKey = form.getFieldValue(providerConfig[selectedProvider as keyof typeof providerConfig].apiKeyField)
+    const apiKey: string = form.getFieldValue(providerConfig[selectedProvider as keyof typeof providerConfig].apiKeyField) || ''
+    const baseUrl = selectedProvider === 'openai' ? normalizeBaseUrl(form.getFieldValue('openai_base_url')) : ''
+    const modelName = normalizeModelName(form.getFieldValue('model_name'))
     
-    if (!apiKey || apiKey.trim() === '') {
+    // 自建兼容服务（Ollama / vLLM 等）通常不需要 key，有地址就能测
+    if (!apiKey.trim() && !baseUrl) {
       message.error('请先输入API密钥')
       return
     }
 
     try {
       setLoading(true)
-      const result = await settingsApi.testApiKey(selectedProvider, apiKey)
+      const result = await settingsApi.testApiKey(selectedProvider, apiKey, {
+        baseUrl: baseUrl || undefined,
+        model: modelName || undefined,
+      })
       if (result.success) {
         message.success('API密钥测试成功！')
       } else {
@@ -269,6 +289,9 @@ const SettingsPage: React.FC = () => {
     setSelectedProvider(provider)
     form.setFieldsValue({ llm_provider: provider })
   }
+
+  const openaiBaseUrl = Form.useWatch('openai_base_url', form)
+  const usingCustomEndpoint = selectedProvider === 'openai' && !!normalizeBaseUrl(openaiBaseUrl)
 
   return (
     <Content className="settings-page">
@@ -304,7 +327,7 @@ const SettingsPage: React.FC = () => {
                 {/* 当前提供商状态 */}
                 {currentProvider.available && (
                   <Alert
-                    message={`当前使用: ${currentProvider.display_name} - ${currentProvider.model}`}
+                    message={`当前使用: ${currentProvider.display_name} - ${currentProvider.model}${currentProvider.base_url ? `（${currentProvider.base_url}）` : ''}`}
                     type="success"
                     showIcon
                     style={{ marginBottom: 24 }}
@@ -336,12 +359,39 @@ const SettingsPage: React.FC = () => {
                   </Select>
                 </Form.Item>
 
+                {/* OpenAI 兼容接口地址：智谱 / DeepSeek / OpenRouter / Ollama / vLLM 等都走这里 */}
+                {selectedProvider === 'openai' && (
+                  <Form.Item
+                    label="接口地址（Base URL）"
+                    name="openai_base_url"
+                    className="form-item"
+                    extra="留空使用 OpenAI 官方地址。填兼容服务地址即可接入其他模型，例如 https://open.bigmodel.cn/api/paas/v4、https://api.deepseek.com/v1、http://localhost:11434/v1（Ollama）"
+                    rules={[
+                      {
+                        validator: (_, value) => {
+                          const url = normalizeBaseUrl(value)
+                          if (!url || /^https?:\/\/\S+$/.test(url)) return Promise.resolve()
+                          return Promise.reject(new Error('请输入以 http:// 或 https:// 开头的地址'))
+                        },
+                      },
+                    ]}
+                  >
+                    <Input
+                      placeholder="https://api.openai.com/v1"
+                      prefix={<ApiOutlined />}
+                      className="settings-input"
+                      allowClear
+                    />
+                  </Form.Item>
+                )}
+
                 {/* 动态API密钥输入 */}
                 <Form.Item
                   label={`${providerConfig[selectedProvider as keyof typeof providerConfig].name} API Key`}
                   name={providerConfig[selectedProvider as keyof typeof providerConfig].apiKeyField}
                   className="form-item"
-                  rules={[
+                  extra={usingCustomEndpoint ? '自建 / 本地兼容服务不校验密钥时可留空' : undefined}
+                  rules={usingCustomEndpoint ? [] : [
                     { required: true, message: '请输入API密钥' },
                     { min: 10, message: 'API密钥长度不能少于10位' }
                   ]}
@@ -359,7 +409,9 @@ const SettingsPage: React.FC = () => {
                   name="model_name"
                   className="form-item"
                   rules={[{ required: true, message: '请输入或选择模型名称' }]}
-                  extra="支持手动输入模型名称或从常用模型中选择"
+                  extra={usingCustomEndpoint
+                    ? '请填写该服务实际提供的模型名（如 glm-4-flash、deepseek-chat、qwen2.5:7b），输入后回车确认'
+                    : '支持手动输入模型名称或从常用模型中选择'}
                 >
                   <Select
                     className="settings-input"

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -197,10 +197,16 @@ export const settingsApi = {
   },
 
   // 测试API密钥
-  testApiKey: (provider: string, apiKey: string): Promise<{ success: boolean; error?: string }> => {
+  testApiKey: (
+    provider: string,
+    apiKey: string,
+    options: { baseUrl?: string; model?: string } = {}
+  ): Promise<{ success: boolean; error?: string }> => {
     return api.post('/settings/test-api', { 
       provider, 
-      api_key: apiKey
+      api_key: apiKey,
+      base_url: options.baseUrl,
+      model: options.model,
     })
   },
 

--- a/frontend/src/utils/apiConfigCheck.tsx
+++ b/frontend/src/utils/apiConfigCheck.tsx
@@ -90,11 +90,14 @@ export const checkApiConfig = async (): Promise<ApiConfigStatus> => {
         hasValidKey = !!currentApiKey.trim()
         console.log('DashScope API Key检查:', { hasKey: !!currentApiKey, keyLength: currentApiKey.length, isValid: hasValidKey })
         break
-      case 'openai':
+      case 'openai': {
         currentApiKey = apiKeys.openai || ''
-        hasValidKey = !!currentApiKey.trim()
-        console.log('OpenAI API Key检查:', { hasKey: !!currentApiKey, keyLength: currentApiKey.length, isValid: hasValidKey })
+        // 自建 OpenAI 兼容服务（Ollama / vLLM 等）可以没有 key，只要配了接口地址就算可用
+        const hasCustomBaseUrl = !!(settings.api.api_base_url || '').trim()
+        hasValidKey = !!currentApiKey.trim() || hasCustomBaseUrl
+        console.log('OpenAI API Key检查:', { hasKey: !!currentApiKey, keyLength: currentApiKey.length, hasCustomBaseUrl, isValid: hasValidKey })
         break
+      }
       case 'gemini':
         currentApiKey = apiKeys.gemini || ''
         hasValidKey = !!currentApiKey.trim()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

- #72 / #57 ask for local models and other vendors (Zhipu, DeepSeek, …). Nearly all of them speak the OpenAI protocol, so a configurable `base_url` on the existing OpenAI provider covers them without adding a provider per vendor (this supersedes #78, which hard-codes one vendor).
- While wiring this up I found the provider selection in the settings page was **never persisted**: `ApiSettings` had no provider field, `/settings/current-provider` always returned `dashscope`, and `LLMManager` defaulted to `dashscope` when reading the client-format `settings.json`. In other words switching to OpenAI/Gemini/SiliconFlow in the UI did not affect the pipeline. That is fixed here as well.
- `LLMManager` also only read `settings.json`, so the documented `API_DASHSCOPE_API_KEY` etc. env vars were ignored in Docker, where the settings page is disabled anyway.

## What

**Backend**
- `OpenAIProvider` takes `base_url` (settings or `OPENAI_BASE_URL`); custom endpoints skip the `sk-` key format check and get a placeholder key when none is supplied (Ollama / vLLM / LM Studio).
- `ApiSettings` gains `api_provider` and `api_base_url`; `/settings/test-api` accepts `base_url` + `model`; `/settings/current-provider` reports the real state from `LLMManager`.
- `LLMManager`
  - reads `api_provider` / `api_base_url` from `settings.json`;
  - reloads when the file's mtime changes, so the API process **and the Celery worker** pick up new settings without a restart;
  - env fallbacks for Docker: `LLM_PROVIDER`, `OPENAI_BASE_URL`, `API_MODEL_NAME`, `API_{DASHSCOPE,OPENAI,GEMINI,SILICONFLOW}_API_KEY` (a value saved in `settings.json` always wins);
  - resolves `settings.json` through `path_utils.get_data_directory()` so it reads the same file the settings API writes.
- `env.example` documents the new variables with Zhipu / DeepSeek / Ollama examples.

**Frontend**
- Settings page: "接口地址（Base URL）" field shown for the OpenAI provider; API key becomes optional when a custom endpoint is set; model hint tells users to enter the endpoint's real model name.
- `api_provider` / `api_base_url` are saved and restored; the `mode="tags"` model select value is normalized to a string before saving (it previously could send an array and fail validation).
- First-run wizard and `apiConfigCheck` treat a keyless custom endpoint as configured.

## Tests

- New `backend/tests/test_llm_provider_config.py` (11 cases): provider construction with/without base_url, env base_url, keyless endpoint, manager honours saved provider/base_url, mtime hot reload, env fallbacks vs. file precedence, `/test-api` with keyless custom endpoint and official key validation.
- `pytest backend/tests`: 114 passed. Frontend `lint` and `build` pass (`typecheck` failures are the pre-existing `Timeout` ones fixed in #89).
- Merges cleanly with #89 / #91; merged tree also passes all tests.

Closes #72, closes #57. Supersedes #78.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a076e0-b655-7492-b632-bb1d09bb85bc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a076e0-b655-7492-b632-bb1d09bb85bc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

