### PR TITLE
build(desktop): Windows x64 packaging script + workflow (shared PBS steps with macOS)

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -1,40 +1,50 @@
-name: Desktop Build (macOS arm64)
+name: Desktop Build
 
 # Single, unified desktop packaging pipeline.
 #
 # This replaces the old PyInstaller / prepare_resources workflows (build-*.yml),
 # none of which ever produced a working installable app (see issue #65). It runs
-# the proven python-build-standalone (PBS) route in scripts/build_macos_arm.sh:
-# portable Python + backend source + static ffmpeg/ffprobe, injected into the
-# .app, ad-hoc signed, packaged as a DMG.
+# the proven python-build-standalone (PBS) route: portable Python + backend
+# source + static ffmpeg/ffprobe, packaged per platform:
+#   - macOS arm64:  scripts/build_macos_arm.sh   -> .app injected + ad-hoc signed + DMG
+#   - Windows x64:  scripts/build_windows_x64.sh -> NSIS installer (resources declared
+#                   in src-tauri/tauri.windows.conf.json)
+# Both share scripts/lib/desktop_build_common.sh.
 #
 # Triggers:
-#   - workflow_dispatch: build on demand
-#   - push tags v*:      build + attach the DMG to a GitHub Release
-#
-# Currently macOS arm64 only (the validated target). PBS and the static ffmpeg
-# source both have x86_64/Windows/Linux equivalents, so the same script can be
-# generalized later by parameterizing the runner + download URLs + tauri target.
+#   - workflow_dispatch: build on demand (pick platforms)
+#   - push tags v*:      build + attach the artifacts to a GitHub Release
 
 on:
   workflow_dispatch:
+    inputs:
+      build_macos:
+        description: "Build macOS arm64 DMG"
+        type: boolean
+        default: true
+      build_windows:
+        description: "Build Windows x64 installer"
+        type: boolean
+        default: true
   push:
     tags:
       - 'v*'
 
 # Needed by softprops/action-gh-release to create the Release and upload the
-# DMG. Without this the default GITHUB_TOKEN is read-only and the release step
-# fails with "Resource not accessible by integration" (403).
+# artifacts. Without this the default GITHUB_TOKEN is read-only and the release
+# step fails with "Resource not accessible by integration" (403).
 permissions:
   contents: write
 
+env:
+  # GitHub runners are in the US; the default tsinghua mirror in the build
+  # script is slow/unreliable from there, so use PyPI directly.
+  PIP_INDEX_URL: https://pypi.org/simple
+
 jobs:
   build-macos-arm64:
+    if: github.event_name == 'push' || inputs.build_macos
     runs-on: macos-14  # Apple Silicon runner
-    env:
-      # GitHub runners are in the US; the default tsinghua mirror in the build
-      # script is slow/unreliable from there, so use PyPI directly.
-      PIP_INDEX_URL: https://pypi.org/simple
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -62,7 +72,7 @@ jobs:
           path: |
             build/pbs-cache
             build/ffmpeg-cache
-          key: desktop-downloads-${{ hashFiles('scripts/build_macos_arm.sh') }}
+          key: desktop-downloads-macos-${{ hashFiles('scripts/build_macos_arm.sh', 'scripts/lib/desktop_build_common.sh') }}
 
       - name: Install Tauri CLI
         run: cargo install tauri-cli --locked --version "^2.0"
@@ -85,18 +95,105 @@ jobs:
           path: src-tauri/target/release/bundle/macos/*.dmg
           retention-days: 30
 
-      - name: Attach DMG to release
-        if: startsWith(github.ref, 'refs/tags/v')
+  build-windows-x64:
+    if: github.event_name == 'push' || inputs.build_windows
+    runs-on: windows-latest
+    defaults:
+      run:
+        # Git Bash: the build script is bash and shares its library with macOS.
+        shell: bash
+    steps:
+      # The runner's git defaults to autocrlf=true; CRLF shell scripts fail in
+      # bash with "$'\r': command not found". (.gitattributes enforces LF for
+      # *.sh as well, this is belt and braces for older checkouts.)
+      - name: Force LF line endings
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Cache portable Python + ffmpeg downloads
+        uses: actions/cache@v4
+        with:
+          path: |
+            build/pbs-cache
+            build/ffmpeg-cache
+          key: desktop-downloads-windows-${{ hashFiles('scripts/build_windows_x64.sh', 'scripts/lib/desktop_build_common.sh') }}
+
+      - name: Install Tauri CLI
+        run: cargo install tauri-cli --locked --version "^2.0"
+
+      - name: Build desktop app (PBS route)
+        env:
+          VITE_PUBLIC_POSTHOG_KEY: ${{ secrets.VITE_PUBLIC_POSTHOG_KEY }}
+          VITE_PUBLIC_POSTHOG_HOST: ${{ vars.VITE_PUBLIC_POSTHOG_HOST || 'https://us.i.posthog.com' }}
+        run: bash scripts/build_windows_x64.sh
+
+      - name: Upload installer artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: autoclip-desktop-windows-x64
+          path: src-tauri/target/release/bundle/nsis/*.exe
+          retention-days: 30
+
+  # One release job instead of per-platform upload steps, so two jobs never race
+  # to create the same tag's release. Runs even if one platform failed, so a
+  # broken Windows build doesn't block the macOS DMG (and vice versa).
+  release:
+    if: startsWith(github.ref, 'refs/tags/v') && !cancelled()
+    needs: [build-macos-arm64, build-windows-x64]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: autoclip-desktop-*
+          path: dist
+          merge-multiple: true
+
+      - name: List artifacts
+        run: ls -la dist
+
+      - name: Create / update GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: src-tauri/target/release/bundle/macos/*.dmg
+          files: dist/*
           body: |
-            ## AutoClip Desktop ${{ github.ref_name }} (macOS, Apple Silicon)
+            ## AutoClip Desktop ${{ github.ref_name }}
 
+            ### macOS (Apple Silicon) — `.dmg`
             - Built-in portable Python runtime + static ffmpeg/ffprobe — no
               dependencies to install.
             - Ad-hoc signed (not notarized): on first launch, right-click the
               app and choose **Open** to bypass Gatekeeper.
             - Apple Silicon (arm64) only.
+
+            ### Windows (x64) — `-setup.exe`
+            - Same bundled runtime; installs per-user, no admin rights needed.
+            - Not code-signed: SmartScreen will warn on first run — choose
+              **More info → Run anyway**.
+            - WebView2 is downloaded by the installer if missing.
+
+            If one of the files is missing, that platform's build failed for this
+            tag — check the Desktop Build workflow run.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,11 +7,15 @@
 
 | 脚本 | 用途 |
 |------|------|
-| `build_macos_arm.sh` | **唯一的桌面打包脚本**（macOS Apple Silicon）。端到端产出 `.app` + `.dmg`。 |
+| `build_macos_arm.sh` | 桌面打包（macOS Apple Silicon）。端到端产出 `.app` + `.dmg`。 |
+| `build_windows_x64.sh` | 桌面打包（Windows x64）。在 Git Bash 里跑，产出 NSIS 安装包 `*-setup.exe`。 |
+| `lib/desktop_build_common.sh` | 上面两个脚本共用的平台无关步骤（便携 Python 下载、pip、后端拷贝、依赖检查、前端构建）。不直接执行。 |
 | `verify_desktop.sh` | 后端冒烟测试：`cargo check` + 起后端，校验 `/health` 与 `/api/v1/video-categories`。被 `nightly-desktop-smoke.yml` 调用。 |
 | `monitor_whisper.py` | 运行期 Whisper 任务监控，被根目录 `start_autoclip.sh` / `check_whisper_status.sh` 调用。 |
 
-## 打包桌面客户端（macOS arm64）
+## 打包桌面客户端
+
+### macOS arm64
 
 ```bash
 ./scripts/build_macos_arm.sh
@@ -21,38 +25,65 @@
 ```
 src-tauri/target/release/bundle/macos/
 ├── AutoClip Desktop.app
-└── AutoClip Desktop_1.0.0_aarch64.dmg
+└── AutoClip Desktop_<version>_aarch64.dmg
 ```
 
-### 这个脚本做了什么
+### Windows x64
 
-1. 下载便携 Python 运行时（python-build-standalone，缓存在 `build/pbs-cache/`）
+在 **Git Bash** 中执行（需要 Node.js、Rust MSVC 工具链、Visual Studio Build Tools C++ 组件、cargo-tauri）：
+
+```bash
+bash scripts/build_windows_x64.sh
+```
+
+产物：
+```
+src-tauri/target/release/bundle/nsis/
+└── AutoClip Desktop_<version>_x64-setup.exe
+```
+
+Windows 与 macOS 的唯一结构差异：macOS 是构建后把 `python/ backend/ ffmpeg/` 注入 `.app`
+再签名；Windows 的安装包没法事后注入，所以资源在 `src-tauri/tauri.windows.conf.json`
+的 `bundle.resources` 里声明，由 Tauri 打进 NSIS。这个文件只在 Windows 上构建时才会被
+Tauri 合并，不影响 macOS。
+
+### 两个脚本共同做了什么（`lib/desktop_build_common.sh`）
+
+1. 下载便携 Python 运行时（python-build-standalone，缓存在 `build/pbs-cache/`；国内镜像优先，自动回退）
 2. 用便携 Python 安装 `requirements.txt` 的全部依赖
-3. **依赖完整性检查**：AST 扫描后端所有第三方 import，缺任何一个就让构建失败
+3. 拷贝后端源码到 `src-tauri/resources/backend/`（排除缓存 / tests / 运行数据；用 Python `shutil` 实现，Windows 没有 rsync）
+4. **依赖完整性检查**：AST 扫描后端所有第三方 import，缺任何一个就让构建失败
    （防止"开发机能跑、打包就 500"）
-4. rsync 拷贝后端源码到 `src-tauri/resources/backend/`
-5. 下载**静态** ffmpeg + ffprobe（arm64，自包含，零 homebrew 依赖，缓存在 `build/ffmpeg-cache/`）
-6. 构建前端（`npm ci && npm run build`）
-7. `cargo tauri build --bundles app`
-8. 把 `python/`、`backend/`、`ffmpeg/` 注入 `.app/Contents/Resources/resources/`
-9. ad-hoc 签名 + `hdiutil` 手动打 DMG
+5. 构建前端（`npm ci && npm run build`）
+
+平台脚本各自负责：静态 ffmpeg/ffprobe（macOS: osxexperts arm64 静态包；Windows: BtbN win64 gpl 包）、
+`cargo tauri build`、打包与签名。
+
+### 运行时怎么找到这些资源（`src-tauri/src/backend_manager.rs`）
+
+- Python：`resources/python/bin/python3`（unix）或 `resources/python/python.exe`（Windows）
+- ffmpeg：`resources/ffmpeg/ffmpeg[.exe]`，通过 `AUTOCLIP_FFMPEG_PATH` / `AUTOCLIP_FFPROBE_PATH` 传给后端
+- 数据目录：Rust 侧设置 `AUTOCLIP_APP_DIR=<平台数据目录>/AutoClip`
+  （macOS `~/Library/Application Support/AutoClip`，Windows `%APPDATA%\AutoClip`）
+- Windows 额外：`PYTHONUTF8=1`（后端 stdout 有 emoji，否则 GBK 控制台直接 UnicodeEncodeError）、
+  `CREATE_NO_WINDOW`（不弹黑框）
 
 ### 前置依赖
 
-- Node.js 18+、Rust（带 `aarch64-apple-darwin` target）、cargo-tauri (`cargo install tauri-cli`)
+- Node.js 18+、Rust、cargo-tauri (`cargo install tauri-cli`)
+- macOS：`aarch64-apple-darwin` target；Windows：MSVC 工具链 + VS Build Tools
 - 系统 **不需要** 预装 Python / ffmpeg —— 脚本会自带便携版
 
 ### 环境变量
 
 - `PIP_INDEX_URL`：pip 源，默认清华镜像；CI 里设为 `https://pypi.org/simple`
+- `PBS_VERSION` / `PBS_PYTHON_VERSION`：覆盖便携 Python 版本（默认见 `lib/desktop_build_common.sh`）
 
 ## CI
 
-`.github/workflows/desktop-build.yml` 在 `workflow_dispatch` 和 `v*` tag 上跑同一个
-`build_macos_arm.sh`，打 tag 时把 DMG 挂到 GitHub Release。
-
-> 当前仅 macOS arm64。PBS 与静态 ffmpeg 对 Intel/Windows/Linux 都有对应版本，
-> 后续把 runner、下载 URL、tauri target 参数化即可泛化。
+`.github/workflows/desktop-build.yml`：
+- `workflow_dispatch`：可勾选只构建 macOS 或只构建 Windows
+- `v*` tag：两个平台并行构建，`release` job 汇总产物挂到 GitHub Release（任一平台失败不阻塞另一平台上传）
 
 ## 开发模式（不打包）
 

--- a/scripts/build_macos_arm.sh
+++ b/scripts/build_macos_arm.sh
@@ -2,6 +2,10 @@
 # AutoClip Desktop macOS Apple Silicon build
 # Bundles a portable python-build-standalone Python runtime + backend source
 # so end users can double-click to run without installing Python.
+#
+# Platform-neutral steps (portable Python, pip, backend copy, dependency check,
+# frontend) live in scripts/lib/desktop_build_common.sh and are shared with
+# scripts/build_windows_x64.sh. Only the macOS-specific parts are here.
 
 set -e
 
@@ -10,161 +14,16 @@ echo "==> AutoClip Desktop build (macOS arm64)"
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$PROJECT_ROOT"
 
-# ---- prerequisite checks ----
-echo "==> Checking build environment"
-for cmd in node python3 cargo; do
-    if ! command -v "$cmd" &> /dev/null; then
-        echo "ERROR: $cmd not installed"; exit 1
-    fi
-done
-if ! command -v tauri &> /dev/null && ! command -v cargo-tauri &> /dev/null; then
-    if ! cargo tauri --version &> /dev/null; then
-        echo "ERROR: tauri CLI not installed (run: cargo install tauri-cli)"; exit 1
-    fi
-fi
-echo "OK"
+PBS_TRIPLE="aarch64-apple-darwin"
+PORTABLE_PY_REL="bin/python3"
+# shellcheck source=lib/desktop_build_common.sh
+source "$PROJECT_ROOT/scripts/lib/desktop_build_common.sh"
 
-RESOURCES_DIR="src-tauri/resources"
-
-# ---- portable Python runtime ----
-PBS_VERSION="20260510"
-PBS_PYTHON_VERSION="3.13.13"
-PBS_TARBALL="cpython-${PBS_PYTHON_VERSION}+${PBS_VERSION}-aarch64-apple-darwin-install_only.tar.gz"
-# Mirrors (first that works wins). ghproxy.com is a github release proxy commonly
-# used in CN; falls back to direct github + jsdelivr cdn.
-PBS_URLS=(
-    "https://ghproxy.com/https://github.com/astral-sh/python-build-standalone/releases/download/${PBS_VERSION}/${PBS_TARBALL}"
-    "https://mirror.ghproxy.com/https://github.com/astral-sh/python-build-standalone/releases/download/${PBS_VERSION}/${PBS_TARBALL}"
-    "https://github.com/astral-sh/python-build-standalone/releases/download/${PBS_VERSION}/${PBS_TARBALL}"
-)
-PBS_CACHE="build/pbs-cache/${PBS_TARBALL}"
-
-echo "==> Preparing portable Python runtime"
-mkdir -p "build/pbs-cache"
-# Sanity check: PBS install_only tarballs are ~25MB. Anything smaller is a partial download.
-PBS_MIN_BYTES=20000000
-if [ -f "$PBS_CACHE" ]; then
-    cached_size=$(stat -f %z "$PBS_CACHE" 2>/dev/null || stat -c %s "$PBS_CACHE" 2>/dev/null || echo 0)
-    if [ "$cached_size" -lt "$PBS_MIN_BYTES" ]; then
-        echo "  Cached file too small ($cached_size bytes), redownloading"
-        rm -f "$PBS_CACHE"
-    fi
-fi
-if [ ! -f "$PBS_CACHE" ]; then
-    for url in "${PBS_URLS[@]}"; do
-        echo "  Trying: $url"
-        if curl -L --fail --connect-timeout 15 --max-time 600 -o "$PBS_CACHE.tmp" "$url"; then
-            tmp_size=$(stat -f %z "$PBS_CACHE.tmp" 2>/dev/null || stat -c %s "$PBS_CACHE.tmp" 2>/dev/null || echo 0)
-            if [ "$tmp_size" -ge "$PBS_MIN_BYTES" ]; then
-                mv "$PBS_CACHE.tmp" "$PBS_CACHE"
-                break
-            else
-                echo "  Download too small ($tmp_size bytes), trying next mirror..."
-                rm -f "$PBS_CACHE.tmp"
-            fi
-        else
-            rm -f "$PBS_CACHE.tmp"
-            echo "  Failed, trying next mirror..."
-        fi
-    done
-    if [ ! -f "$PBS_CACHE" ]; then
-        echo "ERROR: failed to download Python runtime from all mirrors"
-        echo "       You can download it manually:"
-        echo "         ${PBS_URLS[0]}"
-        echo "       and place it at: $PBS_CACHE"
-        exit 1
-    fi
-fi
-echo "  Cached: $PBS_CACHE ($(du -h "$PBS_CACHE" | awk '{print $1}'))"
-
-PYTHON_DIR="$RESOURCES_DIR/python"
-rm -rf "$PYTHON_DIR"
-mkdir -p "$RESOURCES_DIR"
-tar -xzf "$PBS_CACHE" -C "$RESOURCES_DIR"
-# PBS extracts into ./python — move into resources/python (already correct)
-echo "OK"
-
-PORTABLE_PY="$PYTHON_DIR/bin/python3"
-"$PORTABLE_PY" -V
-
-# ---- install backend Python deps into the portable runtime ----
-echo "==> Installing backend Python dependencies into portable runtime"
-PIP_INDEX="${PIP_INDEX_URL:-https://pypi.tuna.tsinghua.edu.cn/simple}"
-"$PORTABLE_PY" -m pip install --upgrade pip --quiet --index-url "$PIP_INDEX"
-"$PORTABLE_PY" -m pip install -r requirements.txt --quiet --index-url "$PIP_INDEX"
-echo "OK"
-
-# ---- copy backend source ----
-echo "==> Copying backend source"
-BACKEND_DEST="$RESOURCES_DIR/backend"
-rm -rf "$BACKEND_DEST"
-mkdir -p "$BACKEND_DEST"
-# Use rsync to exclude noise
-rsync -a \
-    --exclude='__pycache__/' \
-    --exclude='*.pyc' \
-    --exclude='.pytest_cache/' \
-    --exclude='.mypy_cache/' \
-    --exclude='.ruff_cache/' \
-    --exclude='tests/' \
-    --exclude='data/' \
-    --exclude='logs/' \
-    --exclude='temp/' \
-    --exclude='*.log' \
-    --exclude='*.pid' \
-    --exclude='*.rdb' \
-    backend/ "$BACKEND_DEST/"
-echo "OK"
-
-# ---- dependency completeness check ----
-# Guard against the classic "works in dev, broken in the bundle" trap: the dev
-# venv accumulates packages that requirements.txt never listed, so the portable
-# runtime ships without them and the backend 500s at runtime (e.g. pytz, the
-# LLM SDKs). Statically scan the copied backend for third-party imports and
-# assert every one resolves in the portable runtime. Fail the build if not.
-echo "==> Verifying backend dependencies are present in portable runtime"
-"$PORTABLE_PY" - "$BACKEND_DEST" <<'PY'
-import ast, os, sys, importlib.util
-backend_dir = sys.argv[1]
-# Make the bundle's own packages resolvable (both `import backend.x` and `from core import x` styles).
-sys.path.insert(0, os.path.dirname(backend_dir))  # parent → resolves `backend`
-sys.path.insert(0, backend_dir)                   # backend → resolves `core`, `app`, ...
-stdlib = set(sys.stdlib_module_names)
-# Modules that are installed AT RUNTIME by the user (Whisper feature), not
-# bundled. They are imported lazily inside functions and must NOT fail the
-# build. Keep this list tight.
-runtime_optional = {"faster_whisper", "ctranslate2", "huggingface_hub"}
-mods = set()
-for root, _, files in os.walk(backend_dir):
-    if '__pycache__' in root:
-        continue
-    for f in files:
-        if not f.endswith('.py'):
-            continue
-        try:
-            tree = ast.parse(open(os.path.join(root, f), encoding='utf-8').read())
-        except Exception:
-            continue
-        for n in ast.walk(tree):
-            if isinstance(n, ast.Import):
-                for a in n.names:
-                    mods.add(a.name.split('.')[0])
-            elif isinstance(n, ast.ImportFrom) and n.level == 0 and n.module:
-                mods.add(n.module.split('.')[0])
-missing = sorted(
-    m for m in mods
-    if m and not m.startswith('_') and m not in stdlib
-    and m not in runtime_optional
-    and importlib.util.find_spec(m) is None
-)
-if missing:
-    print("ERROR: backend imports modules missing from the portable runtime:")
-    for m in missing:
-        print("  -", m)
-    print("Add them to requirements.txt so the bundle installs them.")
-    sys.exit(1)
-print("OK (all backend imports resolve)")
-PY
+check_build_tools
+prepare_portable_python
+install_backend_deps
+copy_backend_source
+verify_backend_deps
 
 # ---- ffmpeg ----
 # We bundle STATIC, self-contained ffmpeg + ffprobe (arm64). Do NOT copy the
@@ -173,7 +32,6 @@ PY
 echo "==> Bundling static ffmpeg + ffprobe (arm64)"
 mkdir -p "$RESOURCES_DIR/ffmpeg"
 FFMPEG_CACHE="build/ffmpeg-cache"
-mkdir -p "$FFMPEG_CACHE"
 # Static arm64 builds from osxexperts.net (zero non-system dylib deps).
 FFMPEG_MIN_BYTES=15000000  # static binaries are ~48MB; zips ~20MB
 declare -a FF_NAMES=("ffmpeg" "ffprobe")
@@ -183,28 +41,15 @@ declare -a FF_URLS=(
 )
 for i in 0 1; do
     name="${FF_NAMES[$i]}"
-    url="${FF_URLS[$i]}"
     zip_cache="$FFMPEG_CACHE/${name}.zip"
-    if [ -f "$zip_cache" ]; then
-        sz=$(stat -f %z "$zip_cache" 2>/dev/null || stat -c %s "$zip_cache" 2>/dev/null || echo 0)
-        [ "$sz" -lt "$FFMPEG_MIN_BYTES" ] && { echo "  cached $name zip too small, redownloading"; rm -f "$zip_cache"; }
-    fi
-    if [ ! -f "$zip_cache" ]; then
-        echo "  Downloading static $name: $url"
-        if ! curl -L --fail --connect-timeout 15 --max-time 300 -o "$zip_cache.tmp" "$url"; then
-            echo "ERROR: failed to download static $name from $url"; rm -f "$zip_cache.tmp"; exit 1
-        fi
-        mv "$zip_cache.tmp" "$zip_cache"
-    fi
-    # Extract just the binary into the bundle (ditto strips xattrs that trip Tauri's scanner)
-    tmp_extract="$FFMPEG_CACHE/extract-$name"
-    rm -rf "$tmp_extract"; mkdir -p "$tmp_extract"
-    unzip -o -q "$zip_cache" -d "$tmp_extract"
-    src_bin="$(find "$tmp_extract" -type f -name "$name" | head -1)"
-    if [ -z "$src_bin" ]; then echo "ERROR: $name binary not found inside $zip_cache"; exit 1; fi
-    ditto --noacl --noextattr "$src_bin" "$RESOURCES_DIR/ffmpeg/$name"
+    download_with_mirrors "$zip_cache" "$FFMPEG_MIN_BYTES" "${FF_URLS[$i]}"
+    # Extract just the binary, then ditto it into place (ditto strips xattrs that trip Tauri's scanner)
+    tmp_bin="$FFMPEG_CACHE/extract-$name/$name"
+    rm -rf "$FFMPEG_CACHE/extract-$name"
+    extract_from_zip "$zip_cache" "$name" "$tmp_bin"
+    ditto --noacl --noextattr "$tmp_bin" "$RESOURCES_DIR/ffmpeg/$name"
     chmod 755 "$RESOURCES_DIR/ffmpeg/$name"
-    rm -rf "$tmp_extract"
+    rm -rf "$FFMPEG_CACHE/extract-$name"
 done
 # Sanity: bundled binaries must have no homebrew dylib deps
 for name in ffmpeg ffprobe; do
@@ -215,13 +60,7 @@ for name in ffmpeg ffprobe; do
 done
 echo "OK (ffmpeg $(ls -lh "$RESOURCES_DIR/ffmpeg/ffmpeg" | awk '{print $5}'), ffprobe $(ls -lh "$RESOURCES_DIR/ffmpeg/ffprobe" | awk '{print $5}'))"
 
-# ---- frontend ----
-echo "==> Building frontend"
-cd frontend
-npm ci --silent
-npm run build
-cd ..
-echo "OK"
+build_frontend
 
 # ---- Tauri build ----
 echo "==> Building Tauri application (this takes a few minutes)"
@@ -239,7 +78,9 @@ echo "OK"
 # ---- inject resources into .app ----
 # We don't declare resources in tauri.conf.json because Tauri's resource
 # scanner trips on extended attributes / large binaries on macOS 26.
-# Copying them in post-build is reliable.
+# Copying them in post-build is reliable. (Windows declares them in
+# tauri.windows.conf.json instead, since an installer can't be patched after
+# the fact.)
 echo "==> Injecting runtime resources into app bundle"
 APP_RESOURCES="$APP_PATH/Contents/Resources/resources"
 rm -rf "$APP_RESOURCES"
@@ -256,9 +97,7 @@ echo "OK"
 
 # ---- create DMG manually ----
 echo "==> Creating DMG"
-# Read the version from tauri.conf.json so the DMG name never drifts from the app version.
-APP_VERSION=$(grep '"version"' src-tauri/tauri.conf.json | head -1 | sed -E 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')
-APP_VERSION="${APP_VERSION:-1.1.0}"
+APP_VERSION="$(app_version)"
 DMG_PATH="src-tauri/target/release/bundle/macos/AutoClip Desktop_${APP_VERSION}_aarch64.dmg"
 rm -f "$DMG_PATH"
 hdiutil create -volname "AutoClip Desktop" \

--- a/scripts/build_windows_x64.sh
+++ b/scripts/build_windows_x64.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# AutoClip Desktop Windows x64 build
+#
+# Same python-build-standalone route as build_macos_arm.sh: portable Python +
+# backend source + static ffmpeg/ffprobe, packaged by Tauri into an NSIS
+# installer. Run from Git Bash (or the `bash` shell on a GitHub windows-*
+# runner); the shared steps in scripts/lib/desktop_build_common.sh are written
+# to work without rsync / unzip / ditto.
+#
+# Unlike macOS, the runtime resources are declared in
+# src-tauri/tauri.windows.conf.json (bundle.resources) so the installer carries
+# them; an .exe installer can't have files injected after the fact. Tauri only
+# merges that file when building on Windows, so macOS builds are unaffected.
+#
+# Prerequisites on the build machine:
+#   - Node.js 18+, Rust (stable-x86_64-pc-windows-msvc), cargo-tauri
+#   - Visual Studio Build Tools (C++ workload) — required by Tauri on Windows
+#   - Git Bash (provides bash, curl, tar)
+
+set -e
+
+echo "==> AutoClip Desktop build (Windows x64)"
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*) ;;
+    *) echo "ERROR: this script must run on Windows (Git Bash / MSYS). Detected: $(uname -s)"; exit 1 ;;
+esac
+
+PBS_TRIPLE="x86_64-pc-windows-msvc"
+PORTABLE_PY_REL="python.exe"
+# shellcheck source=lib/desktop_build_common.sh
+source "$PROJECT_ROOT/scripts/lib/desktop_build_common.sh"
+
+check_build_tools
+prepare_portable_python
+install_backend_deps
+copy_backend_source
+verify_backend_deps
+
+# ---- ffmpeg ----
+# Static win64 builds. BtbN's "latest" tag is a moving pointer to the current
+# master build; gyan.dev's release-essentials is the fallback. Both zips
+# contain bin/ffmpeg.exe and bin/ffprobe.exe with no external DLL deps.
+echo "==> Bundling static ffmpeg + ffprobe (win64)"
+mkdir -p "$RESOURCES_DIR/ffmpeg"
+FFMPEG_CACHE="build/ffmpeg-cache"
+FFMPEG_ZIP="$FFMPEG_CACHE/ffmpeg-win64.zip"
+download_with_mirrors "$FFMPEG_ZIP" 50000000 \
+    "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-gpl.zip" \
+    "https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-essentials.zip"
+for name in ffmpeg ffprobe; do
+    extract_from_zip "$FFMPEG_ZIP" "$name.exe" "$RESOURCES_DIR/ffmpeg/$name.exe"
+done
+"$RESOURCES_DIR/ffmpeg/ffmpeg.exe" -version | head -1
+echo "OK (ffmpeg $(ls -lh "$RESOURCES_DIR/ffmpeg/ffmpeg.exe" | awk '{print $5}'), ffprobe $(ls -lh "$RESOURCES_DIR/ffmpeg/ffprobe.exe" | awk '{print $5}'))"
+
+# ---- smoke test the portable runtime before spending minutes in cargo ----
+echo "==> Smoke-testing portable runtime imports"
+(cd "$RESOURCES_DIR" && "$PORTABLE_PY" -c "import backend.app_factory, backend.desktop_main; print('OK (backend imports under portable python)')")
+
+build_frontend
+
+# ---- Tauri build ----
+# Tauri merges tauri.windows.conf.json on top of tauri.conf.json here, which
+# declares resources/{python,backend,ffmpeg} and restricts targets to nsis.
+echo "==> Building Tauri application (this takes a few minutes)"
+(cd src-tauri && cargo tauri build --bundles nsis)
+
+APP_VERSION="$(app_version)"
+NSIS_DIR="src-tauri/target/release/bundle/nsis"
+INSTALLER="$(ls "$NSIS_DIR"/*.exe 2>/dev/null | head -1)"
+if [ -z "$INSTALLER" ]; then
+    echo "ERROR: NSIS installer not found under $NSIS_DIR"; exit 1
+fi
+
+# ---- summary ----
+echo ""
+echo "==> Build complete"
+echo "    Version:   $APP_VERSION"
+echo "    Installer: $INSTALLER ($(du -sh "$INSTALLER" | awk '{print $1}'))"

--- a/scripts/lib/desktop_build_common.sh
+++ b/scripts/lib/desktop_build_common.sh
@@ -1,0 +1,238 @@
+#!/bin/bash
+# Shared steps for the AutoClip Desktop bundle (python-build-standalone route).
+#
+# Sourced by scripts/build_macos_arm.sh and scripts/build_windows_x64.sh. Every
+# function here must work on macOS (BSD userland) AND on Git Bash / MSYS on
+# Windows, so: no rsync, no unzip, no ditto, no `stat -f`-only calls. Anything
+# non-trivial is delegated to the portable Python we just downloaded.
+#
+# Callers must `cd` to the project root and define these before sourcing:
+#   PBS_TRIPLE          e.g. aarch64-apple-darwin / x86_64-pc-windows-msvc
+#   PORTABLE_PY_REL     python executable relative to resources/python
+#                       e.g. bin/python3 (unix) / python.exe (windows)
+
+set -e
+
+PBS_VERSION="${PBS_VERSION:-20260510}"
+PBS_PYTHON_VERSION="${PBS_PYTHON_VERSION:-3.13.13}"
+RESOURCES_DIR="src-tauri/resources"
+PYTHON_DIR="$RESOURCES_DIR/python"
+BACKEND_DEST="$RESOURCES_DIR/backend"
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+file_size() {
+    # `wc -c` is the only size probe that behaves the same under BSD (macOS)
+    # and GNU (Linux / Git Bash) userlands. GNU `stat -f %z` "succeeds" but
+    # prints filesystem info, which is what the old stat-based fallback did.
+    if [ -f "$1" ]; then
+        wc -c < "$1" | tr -d '[:space:]'
+    else
+        echo 0
+    fi
+}
+
+human_size() {
+    du -h "$1" | awk '{print $1}'
+}
+
+# download_with_mirrors <dest> <min_bytes> <url>...
+# Tries each URL in order; keeps the first download that is at least
+# <min_bytes> (guards against truncated files / HTML error pages).
+download_with_mirrors() {
+    local dest="$1" min_bytes="$2"
+    shift 2
+    if [ -f "$dest" ]; then
+        local cached_size
+        cached_size=$(file_size "$dest")
+        if [ "$cached_size" -lt "$min_bytes" ]; then
+            echo "  Cached file too small ($cached_size bytes), redownloading"
+            rm -f "$dest"
+        fi
+    fi
+    if [ -f "$dest" ]; then
+        echo "  Cached: $dest ($(human_size "$dest"))"
+        return 0
+    fi
+    mkdir -p "$(dirname "$dest")"
+    local url tmp_size
+    for url in "$@"; do
+        echo "  Trying: $url"
+        if curl -L --fail --connect-timeout 15 --max-time 600 -o "$dest.tmp" "$url"; then
+            tmp_size=$(file_size "$dest.tmp")
+            if [ "$tmp_size" -ge "$min_bytes" ]; then
+                mv "$dest.tmp" "$dest"
+                echo "  Downloaded: $dest ($(human_size "$dest"))"
+                return 0
+            fi
+            echo "  Download too small ($tmp_size bytes), trying next mirror..."
+        else
+            echo "  Failed, trying next mirror..."
+        fi
+        rm -f "$dest.tmp"
+    done
+    echo "ERROR: failed to download from all mirrors:"
+    for url in "$@"; do echo "         $url"; done
+    echo "       You can download it manually and place it at: $dest"
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+# steps
+# ---------------------------------------------------------------------------
+check_build_tools() {
+    echo "==> Checking build environment"
+    local cmd
+    for cmd in node cargo curl tar; do
+        if ! command -v "$cmd" &> /dev/null; then
+            echo "ERROR: $cmd not installed"; exit 1
+        fi
+    done
+    if ! command -v tauri &> /dev/null && ! command -v cargo-tauri &> /dev/null; then
+        if ! cargo tauri --version &> /dev/null; then
+            echo "ERROR: tauri CLI not installed (run: cargo install tauri-cli)"; exit 1
+        fi
+    fi
+    echo "OK"
+}
+
+# Downloads the PBS "install_only" tarball for $PBS_TRIPLE (with CN-friendly
+# mirrors first) and extracts it to src-tauri/resources/python. Sets PORTABLE_PY.
+prepare_portable_python() {
+    : "${PBS_TRIPLE:?PBS_TRIPLE must be set}"
+    : "${PORTABLE_PY_REL:?PORTABLE_PY_REL must be set}"
+    local tarball="cpython-${PBS_PYTHON_VERSION}+${PBS_VERSION}-${PBS_TRIPLE}-install_only.tar.gz"
+    local cache="build/pbs-cache/${tarball}"
+    local release="https://github.com/astral-sh/python-build-standalone/releases/download/${PBS_VERSION}/${tarball}"
+
+    echo "==> Preparing portable Python runtime (${PBS_TRIPLE})"
+    # install_only tarballs are 25-50MB; anything smaller is a partial download.
+    download_with_mirrors "$cache" 20000000 \
+        "https://ghproxy.com/${release}" \
+        "https://mirror.ghproxy.com/${release}" \
+        "${release}"
+
+    rm -rf "$PYTHON_DIR"
+    mkdir -p "$RESOURCES_DIR"
+    tar -xzf "$cache" -C "$RESOURCES_DIR"   # extracts into ./python
+    # Absolute so callers can `cd` (subshells into src-tauri/resources etc.) and still use it.
+    PORTABLE_PY="$(pwd)/$PYTHON_DIR/$PORTABLE_PY_REL"
+    if [ ! -f "$PORTABLE_PY" ]; then
+        echo "ERROR: portable python not found at $PORTABLE_PY after extraction"; exit 1
+    fi
+    "$PORTABLE_PY" -V
+    echo "OK"
+}
+
+install_backend_deps() {
+    echo "==> Installing backend Python dependencies into portable runtime"
+    local pip_index="${PIP_INDEX_URL:-https://pypi.tuna.tsinghua.edu.cn/simple}"
+    "$PORTABLE_PY" -m pip install --upgrade pip --quiet --index-url "$pip_index"
+    "$PORTABLE_PY" -m pip install -r requirements.txt --quiet --index-url "$pip_index"
+    echo "OK"
+}
+
+# Copies backend/ into the bundle, dropping caches, tests and runtime data.
+# Uses Python's shutil so the exclude list behaves identically on every OS.
+copy_backend_source() {
+    echo "==> Copying backend source"
+    rm -rf "$BACKEND_DEST"
+    "$PORTABLE_PY" - backend "$BACKEND_DEST" <<'PY'
+import shutil, sys
+src, dest = sys.argv[1], sys.argv[2]
+IGNORED_DIRS = {"__pycache__", ".pytest_cache", ".mypy_cache", ".ruff_cache", "tests", "data", "logs", "temp"}
+IGNORED_SUFFIXES = (".pyc", ".log", ".pid", ".rdb")
+
+def ignore(_dir, names):
+    return {n for n in names if n in IGNORED_DIRS or n.endswith(IGNORED_SUFFIXES)}
+
+shutil.copytree(src, dest, ignore=ignore)
+PY
+    echo "OK"
+}
+
+# Guard against the classic "works in dev, broken in the bundle" trap: the dev
+# venv accumulates packages that requirements.txt never listed, so the portable
+# runtime ships without them and the backend 500s at runtime (e.g. pytz, the
+# LLM SDKs). Statically scan the copied backend for third-party imports and
+# assert every one resolves in the portable runtime. Fail the build if not.
+verify_backend_deps() {
+    echo "==> Verifying backend dependencies are present in portable runtime"
+    "$PORTABLE_PY" - "$BACKEND_DEST" <<'PY'
+import ast, os, sys, importlib.util
+backend_dir = sys.argv[1]
+# Make the bundle's own packages resolvable (both `import backend.x` and `from core import x` styles).
+sys.path.insert(0, os.path.dirname(backend_dir))  # parent → resolves `backend`
+sys.path.insert(0, backend_dir)                   # backend → resolves `core`, `app`, ...
+stdlib = set(sys.stdlib_module_names)
+# Modules that are installed AT RUNTIME by the user (Whisper feature), not
+# bundled. They are imported lazily inside functions and must NOT fail the
+# build. Keep this list tight.
+runtime_optional = {"faster_whisper", "ctranslate2", "huggingface_hub"}
+mods = set()
+for root, _, files in os.walk(backend_dir):
+    if '__pycache__' in root:
+        continue
+    for f in files:
+        if not f.endswith('.py'):
+            continue
+        try:
+            tree = ast.parse(open(os.path.join(root, f), encoding='utf-8').read())
+        except Exception:
+            continue
+        for n in ast.walk(tree):
+            if isinstance(n, ast.Import):
+                for a in n.names:
+                    mods.add(a.name.split('.')[0])
+            elif isinstance(n, ast.ImportFrom) and n.level == 0 and n.module:
+                mods.add(n.module.split('.')[0])
+missing = sorted(
+    m for m in mods
+    if m and not m.startswith('_') and m not in stdlib
+    and m not in runtime_optional
+    and importlib.util.find_spec(m) is None
+)
+if missing:
+    print("ERROR: backend imports modules missing from the portable runtime:")
+    for m in missing:
+        print("  -", m)
+    print("Add them to requirements.txt so the bundle installs them.")
+    sys.exit(1)
+print("OK (all backend imports resolve)")
+PY
+}
+
+# extract_from_zip <zip> <member-basename> <dest-file>
+# Pulls a single file (matched by basename, first hit wins) out of a zip.
+# Git Bash has no `unzip`, so use Python's zipfile.
+extract_from_zip() {
+    "$PORTABLE_PY" - "$1" "$2" "$3" <<'PY'
+import os, shutil, sys, zipfile
+zip_path, wanted, dest = sys.argv[1:4]
+with zipfile.ZipFile(zip_path) as zf:
+    for info in zf.infolist():
+        if not info.is_dir() and os.path.basename(info.filename) == wanted:
+            os.makedirs(os.path.dirname(dest) or ".", exist_ok=True)
+            with zf.open(info) as src, open(dest, "wb") as out:
+                shutil.copyfileobj(src, out)
+            print(f"  extracted {info.filename} -> {dest}")
+            break
+    else:
+        print(f"ERROR: {wanted} not found inside {zip_path}")
+        sys.exit(1)
+PY
+}
+
+build_frontend() {
+    echo "==> Building frontend"
+    (cd frontend && npm ci --silent && npm run build)
+    echo "OK"
+}
+
+# Reads the version from tauri.conf.json so artifact names never drift from the app version.
+app_version() {
+    local v
+    v=$(grep '"version"' src-tauri/tauri.conf.json | head -1 | sed -E 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')
+    echo "${v:-1.1.0}"
+}

--- a/src-tauri/src/backend_manager.rs
+++ b/src-tauri/src/backend_manager.rs
@@ -67,13 +67,44 @@ impl BackendManager {
         // The backend's ffmpeg_utils reads these env vars before falling back
         // to PATH, so this is what makes video processing work on machines
         // without a system ffmpeg installed.
-        let ffmpeg_bin = launch.working_dir.join("ffmpeg").join("ffmpeg");
+        let ffmpeg_bin = launch
+            .working_dir
+            .join("ffmpeg")
+            .join(Self::exe_name("ffmpeg"));
         if ffmpeg_bin.is_file() {
             cmd.env("AUTOCLIP_FFMPEG_PATH", &ffmpeg_bin);
         }
-        let ffprobe_bin = launch.working_dir.join("ffmpeg").join("ffprobe");
+        let ffprobe_bin = launch
+            .working_dir
+            .join("ffmpeg")
+            .join(Self::exe_name("ffprobe"));
         if ffprobe_bin.is_file() {
             cmd.env("AUTOCLIP_FFPROBE_PATH", &ffprobe_bin);
+        }
+
+        // The backend prints emoji/Chinese to stdout; with a piped stdout on
+        // Windows Python falls back to the ANSI code page and dies with
+        // UnicodeEncodeError before it ever reaches "PORT=". Force UTF-8.
+        cmd.env("PYTHONUTF8", "1");
+        cmd.env("PYTHONIOENCODING", "utf-8");
+
+        // Backend defaults its data dir to ~/Library/Application Support/AutoClip,
+        // which only makes sense on macOS. Resolve the platform data dir here
+        // (%APPDATA%\AutoClip on Windows, ~/.local/share/AutoClip on Linux) —
+        // on macOS this is exactly the old default, so existing installs keep
+        // their data.
+        if std::env::var_os("AUTOCLIP_APP_DIR").is_none() {
+            if let Ok(data_dir) = app_handle.path().data_dir() {
+                cmd.env("AUTOCLIP_APP_DIR", data_dir.join("AutoClip"));
+            }
+        }
+
+        #[cfg(target_os = "windows")]
+        {
+            use std::os::windows::process::CommandExt;
+            const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+            // Without this every launch pops a black console window for python.exe.
+            cmd.creation_flags(CREATE_NO_WINDOW);
         }
 
         match cmd.spawn() {
@@ -172,7 +203,7 @@ impl BackendManager {
                     continue;
                 }
 
-                let venv_python = backend_work_dir.join("venv").join("bin").join("python");
+                let venv_python = Self::venv_python(&backend_work_dir);
                 if venv_python.exists() {
                     return Ok(Self::python_launch(
                         venv_python.to_string_lossy().to_string(),
@@ -180,8 +211,10 @@ impl BackendManager {
                     ));
                 }
 
-                // python-build-standalone bundle: resources/python/bin/python3
-                let pbs_python = backend_work_dir.join("python").join("bin").join("python3");
+                // python-build-standalone bundle:
+                //   unix:    resources/python/bin/python3
+                //   windows: resources/python/python.exe
+                let pbs_python = Self::pbs_python(&backend_work_dir);
                 if pbs_python.exists() {
                     return Ok(Self::python_launch(
                         pbs_python.to_string_lossy().to_string(),
@@ -189,10 +222,8 @@ impl BackendManager {
                     ));
                 }
 
-                if Command::new("python3").arg("--version").output().is_ok() {
-                    return Ok(Self::python_launch("python3".to_string(), backend_work_dir));
-                } else if Command::new("python").arg("--version").output().is_ok() {
-                    return Ok(Self::python_launch("python".to_string(), backend_work_dir));
+                if let Some(system_python) = Self::system_python() {
+                    return Ok(Self::python_launch(system_python, backend_work_dir));
                 }
             }
         }
@@ -202,21 +233,16 @@ impl BackendManager {
             if let Some(project_root) = current_dir.parent() {
                 let backend_dir = project_root.join("backend");
                 if backend_dir.exists() {
-                    let venv_python = project_root.join("venv").join("bin").join("python");
+                    let venv_python = Self::venv_python(project_root);
                     if venv_python.exists() {
                         return Ok(Self::python_launch(
                             venv_python.to_string_lossy().to_string(),
                             project_root.to_path_buf(),
                         ));
                     }
-                    if Command::new("python3").arg("--version").output().is_ok() {
+                    if let Some(system_python) = Self::system_python() {
                         return Ok(Self::python_launch(
-                            "python3".to_string(),
-                            project_root.to_path_buf(),
-                        ));
-                    } else if Command::new("python").arg("--version").output().is_ok() {
-                        return Ok(Self::python_launch(
-                            "python".to_string(),
+                            system_python,
                             project_root.to_path_buf(),
                         ));
                     }
@@ -227,22 +253,58 @@ impl BackendManager {
         if let Ok(current_dir) = std::env::current_dir() {
             let backend_dir = current_dir.join("backend");
             if backend_dir.exists() {
-                let venv_python = current_dir.join("venv").join("bin").join("python");
+                let venv_python = Self::venv_python(&current_dir);
                 if venv_python.exists() {
                     return Ok(Self::python_launch(
                         venv_python.to_string_lossy().to_string(),
                         current_dir,
                     ));
                 }
-                if Command::new("python3").arg("--version").output().is_ok() {
-                    return Ok(Self::python_launch("python3".to_string(), current_dir));
-                } else if Command::new("python").arg("--version").output().is_ok() {
-                    return Ok(Self::python_launch("python".to_string(), current_dir));
+                if let Some(system_python) = Self::system_python() {
+                    return Ok(Self::python_launch(system_python, current_dir));
                 }
             }
         }
 
         Err("找不到可用的 Python 环境或后端代码".to_string())
+    }
+
+    fn exe_name(base: &str) -> String {
+        if cfg!(target_os = "windows") {
+            format!("{}.exe", base)
+        } else {
+            base.to_string()
+        }
+    }
+
+    fn venv_python(root: &std::path::Path) -> PathBuf {
+        if cfg!(target_os = "windows") {
+            root.join("venv").join("Scripts").join("python.exe")
+        } else {
+            root.join("venv").join("bin").join("python")
+        }
+    }
+
+    fn pbs_python(root: &std::path::Path) -> PathBuf {
+        if cfg!(target_os = "windows") {
+            root.join("python").join("python.exe")
+        } else {
+            root.join("python").join("bin").join("python3")
+        }
+    }
+
+    /// First interpreter on PATH that answers `--version`. On Windows `python3`
+    /// is usually the Microsoft Store stub, so prefer plain `python` there.
+    fn system_python() -> Option<String> {
+        let candidates: [&str; 2] = if cfg!(target_os = "windows") {
+            ["python", "python3"]
+        } else {
+            ["python3", "python"]
+        };
+        candidates
+            .iter()
+            .find(|name| Command::new(name).arg("--version").output().is_ok())
+            .map(|name| name.to_string())
     }
 
     fn python_launch(program: String, working_dir: PathBuf) -> BackendLaunch {

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "bundle": {
+    "targets": ["nsis"],
+    "resources": {
+      "resources/python": "resources/python",
+      "resources/backend": "resources/backend",
+      "resources/ffmpeg": "resources/ffmpeg"
+    },
+    "windows": {
+      "nsis": {
+        "installerIcon": "icons/icon.ico",
+        "installMode": "currentUser",
+        "languages": ["SimpChinese", "English"],
+        "displayLanguageSelector": true
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

#73 and the Docker portability report (#88) both come from Windows users who currently have no installable build. The macOS packaging route (python-build-standalone + backend source + static ffmpeg, see `scripts/build_macos_arm.sh`) is the only one that ever worked, and the workflow header already noted it "can be generalized later by parameterizing the runner + download URLs + tauri target". This PR does that generalization and adds the Windows x64 target.

## What

**Shared library — `scripts/lib/desktop_build_common.sh`**
Platform-neutral steps extracted from the macOS script, written to run on BSD userland *and* Git Bash: PBS download with CN mirrors first, pip install, backend copy (Python `shutil.copytree` instead of `rsync`, same exclude list), import-completeness check, zip extraction (`zipfile` instead of `unzip`), frontend build.
Found and fixed one latent bug while doing so: `stat -f %z || stat -c %s` "succeeds" under GNU stat but prints filesystem info, so the min-size guard was broken anywhere except macOS. Now `wc -c`.

**`scripts/build_macos_arm.sh`** — same steps in the same order, now sourcing the lib. macOS-only parts (osxexperts static ffmpeg, `ditto`, `otool` check, `codesign`, `hdiutil`) untouched.

**`scripts/build_windows_x64.sh`** (Git Bash)
- PBS `x86_64-pc-windows-msvc-install_only` (`python/python.exe`; layout verified against the 20260510 release assets)
- BtbN `ffmpeg-master-latest-win64-gpl.zip` with gyan.dev fallback → `resources/ffmpeg/ffmpeg.exe|ffprobe.exe`
- import smoke test of `backend.app_factory` / `backend.desktop_main` under the portable runtime before spending minutes in cargo
- `cargo tauri build --bundles nsis`

**`src-tauri/tauri.windows.conf.json`** — declares `resources/{python,backend,ffmpeg}` and the `nsis` target (per-user install, zh-CN + en). An installer cannot be patched after the fact the way the `.app` is, so resources must go through Tauri here. Tauri only merges this file when building on Windows; macOS behaviour is unchanged.

**`src-tauri/src/backend_manager.rs`**
- looks for `python/python.exe`, `venv/Scripts/python.exe`, `ffmpeg.exe` on Windows
- `PYTHONUTF8=1` / `PYTHONIOENCODING=utf-8`: the backend prints emoji and Chinese to a piped stdout, which on Windows falls back to the ANSI code page and dies with `UnicodeEncodeError` before ever printing `PORT=`
- `AUTOCLIP_APP_DIR=<platform data dir>/AutoClip` (only if unset). On macOS this is exactly the previous hard-coded `~/Library/Application Support/AutoClip`, so existing installs keep their data; on Windows it becomes `%APPDATA%\AutoClip` instead of a literal `Library/Application Support` under the user profile
- `CREATE_NO_WINDOW` so `python.exe` does not pop a console window
- prefers `python` over `python3` on Windows (the latter is usually the Store stub)

**`.github/workflows/desktop-build.yml`**
- `build-windows-x64` on `windows-latest` in Git Bash, `core.autocrlf=false` before checkout (CRLF shell scripts fail in bash)
- `workflow_dispatch` inputs to build only one platform
- per-platform artifacts; a single `release` job attaches whatever was built, so one platform failing does not block the other's upload and two jobs never race to create the same release

`scripts/README.md` updated accordingly.

## Verification

- Cannot run Windows here. What was verified:
  - shared lib executed end-to-end on Linux with the `x86_64-unknown-linux-gnu` PBS build: download + mirror fallback + size guard, pip install, backend copy excludes, dependency scan, zip extraction helper, `import backend.desktop_main` under the portable runtime
  - `cargo check` on the Rust changes (the `cfg(windows)` block uses only std APIs)
  - `bash -n` on all three scripts; workflow YAML parses
- First real check will be `workflow_dispatch` → Windows only. Things most likely to need a follow-up on the actual runner: NSIS packaging time with ~6k Python files, and the WebView2 bootstrapper on the runner image.

Refs #73.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a076e0-b655-7492-b632-bb1d09bb85bc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a076e0-b655-7492-b632-bb1d09bb85bc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

