### PR TITLE
build(deps): pin direct backend dependencies in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,33 +1,63 @@
-fastapi
-uvicorn[standard]
-sqlalchemy
-alembic
-celery[redis]
-redis
-pydantic
-pydantic-settings
-python-multipart
-websockets
-requests
-aiohttp
-aiofiles
-python-jose[cryptography]
-passlib[bcrypt]
-pytest
-pytest-cov
-pytest-mock
-cryptography
-# bilitool>=0.1.3  # 已移除，改用直接API调用
-qrcode[pil]
-yt-dlp>=2024.12.13
-pysrt
-psutil
-pytz
+# Backend runtime dependencies.
+#
+# Direct dependencies are pinned with == so CI, the Docker image and the desktop
+# bundle install the same thing (an unpinned yt-dlp / openai upgrade is exactly
+# how the "works on my machine, breaks in the release" reports happen).
+# Transitive dependencies are left to pip so the same file resolves on
+# Linux (CI / Docker, Python 3.11) and on the macOS / Windows portable
+# runtime (Python 3.13).
+#
+# Versions below are the set that CI's "Backend tests" job and the docker-smoke
+# job both installed on Python 3.11 (2026-09-06). To bump: change a pin, let CI
+# run, done. Run `pip install -r requirements.txt` on Python >= 3.10.
 
-# LLM provider SDKs — required for the AI clipping pipeline. These used to live
-# only in install_llm_dependencies.py (installed separately), so the portable
-# desktop build shipped without them and any provider call failed. Bundle them
-# so the desktop app works out of the box.
-openai>=1.0.0
-google-genai>=1.0.0
-dashscope>=1.10.0
+# --- web framework / server ---
+fastapi==0.141.1
+uvicorn[standard]==0.52.4
+starlette==1.6.0
+python-multipart==0.0.32
+websockets==16.1.1
+aiofiles==25.1.0
+
+# --- data / persistence ---
+sqlalchemy==2.0.52
+alembic==1.19.2
+pydantic==2.13.5
+pydantic-settings==2.15.0
+
+# --- task queue ---
+celery[redis]==5.6.3
+redis==6.4.0
+
+# --- http clients ---
+requests==2.34.2
+aiohttp==3.14.3
+
+# --- auth / crypto ---
+python-jose[cryptography]==3.5.0
+passlib[bcrypt]==1.7.4
+cryptography==50.0.1
+
+# --- media / utilities ---
+# bilitool>=0.1.3  # 已移除，改用直接API调用
+qrcode[pil]==8.2
+yt-dlp==2026.8.19
+pysrt==1.1.2
+psutil==7.2.2
+pytz==2026.3.post1
+
+# --- LLM provider SDKs ---
+# Required for the AI clipping pipeline. These used to live only in
+# install_llm_dependencies.py (installed separately), so the portable desktop
+# build shipped without them and any provider call failed. Bundle them so the
+# desktop app works out of the box.
+openai==3.8.0
+google-genai==2.22.0
+dashscope==1.27.4
+
+# --- test tooling ---
+# Kept here (rather than a separate dev file) because CI, the Dockerfile and the
+# desktop build all install this single file; splitting is a follow-up.
+pytest==9.1.1
+pytest-cov==7.1.0
+pytest-mock==3.15.1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

`requirements.txt` was almost entirely unpinned, so every fresh install (CI, `docker build`, the desktop bundle, a user's venv) could resolve to a different set. The `yt-dlp` / Python 3.9 breakage in #88 and the `google-generativeai` → `google-genai` migration in #84 are both symptoms of that.

## What

- Every **direct** dependency pinned with `==` to the versions that CI's *Backend tests* job and the *docker-smoke* job both installed on Python 3.11 (run [34036797031](https://github.com/zhouxiaoka/autoclip/actions/runs/34036797031), 2026-09-06). No version was changed relative to what CI is already running with today.
- Transitive dependencies are deliberately left to pip so the same file resolves on Linux (3.11) and on the macOS / Windows portable runtime (3.13), where wheels and platform markers (`uvloop` etc.) differ.
- File grouped and commented; `starlette` is pinned explicitly because `backend/core/error_middleware*.py` import it directly.
- Test tooling (`pytest*`) stays in this file for now because the Dockerfile and the desktop build install this single file; splitting into `requirements-dev.txt` is a follow-up.

## Verification

- Installed on the Python 3.13 python-build-standalone runtime (the desktop bundle interpreter): clean install, `pip check` reports no broken requirements, `pytest backend/tests` 103 passed.
- CI on this PR exercises the 3.11 resolution (ubuntu job + `python:3.11-slim` docker-smoke, once #89 lands).

## Bumping

Change a pin, let CI run. Dependabot / Renovate would now have something to act on if we want automated bumps later.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a076e0-b655-7492-b632-bb1d09bb85bc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a076e0-b655-7492-b632-bb1d09bb85bc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

