### PR TITLE
chore: pass LLM env vars into Docker containers + post-merge docs sync (CHANGELOG / HANDOFF / DOCKER.md)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,8 @@ jobs:
           # Bind-mounted dirs are created root-owned by the daemon; the container runs as
           # a non-root user, so pre-create them writable.
           mkdir -p data logs uploads && chmod -R 777 data logs uploads
+          # A throwaway .env, the way DOCKER.md tells users to configure the LLM.
+          printf 'LLM_PROVIDER=openai\nOPENAI_BASE_URL=http://llm.example.test/v1\nAPI_MODEL_NAME=smoke-model\n' > .env
           docker compose up -d --no-build redis autoclip celery-worker
 
       - name: Wait for API health
@@ -99,6 +101,22 @@ jobs:
 
       - name: yt-dlp is importable on the image's Python
         run: docker compose exec -T autoclip python -m yt_dlp --version
+
+      - name: LLM settings from .env reach both api and worker
+        run: |
+          for svc in autoclip celery-worker; do
+            docker compose exec -T "$svc" python - <<'EOF'
+          import os, sys
+          sys.path.insert(0, "/app")
+          from backend.core.llm_manager import LLMManager
+          info = LLMManager().get_current_provider_info()
+          assert info["provider"] == "openai", info
+          assert info["model"] == "smoke-model", info
+          assert info.get("base_url") == "http://llm.example.test/v1", info
+          assert info["available"] is True, info   # keyless custom endpoint is enough
+          print("OK", os.environ.get("HOSTNAME"), info)
+          EOF
+          done
 
       - name: Task submission reaches Redis via REDIS_URL
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,15 @@
 
 > 止血版：让 README 推荐的 `docker compose` 路径和本地脚本路径真正能跑通一次完整处理（issue #88 及其一长串重复 issue）。
 
+### 新增
+- **OpenAI 兼容接口自定义 `base_url`**：设置页 OpenAI 提供商新增「接口地址」，可接智谱 / DeepSeek / OpenRouter / 本地 Ollama、vLLM、LM Studio 等；自建服务可不填 key（#72 #57，替代 #78）
+- **Windows x64 安装包**（首个版本，NSIS，按用户安装）：`scripts/build_windows_x64.sh` + `desktop-build.yml` Windows job；与 macOS 共用 `scripts/lib/desktop_build_common.sh`（#73）
+- Docker / 脚本模式可用环境变量配置 LLM：`LLM_PROVIDER`、`API_MODEL_NAME`、`OPENAI_BASE_URL`、`API_{DASHSCOPE,OPENAI,GEMINI,SILICONFLOW}_API_KEY`；compose 透传给 api 与 worker，CI docker-smoke 断言其生效
+- `requirements.txt` 直接依赖全部锁定版本（与 CI / Docker 实装一致；3.11 与便携 3.13 均可解析）
+
 ### 修复
+- **设置页选择的 LLM 提供商从未被持久化**：`api_provider` / `api_base_url` 现在真正写入 `settings.json` 并被流水线读取；`/settings/current-provider` 不再固定返回通义千问；设置保存后 API 进程与 Celery worker 按文件 mtime 自动重载，不必重启
+- 模型选择框（`mode="tags"`）手动输入后会把数组发给后端导致保存失败，已归一为字符串
 - Docker 镜像无法构建：`.dockerignore` 误排除 `docker-entrypoint.sh` / `docker-dev-entrypoint.sh`（#1 #4 #9 #47 #50 #88）
 - Windows 克隆后容器无法启动：新增 `.gitattributes`，shell 脚本强制 LF 行尾（#73 #88）
 - Docker 下任何任务都不执行：compose / dev compose 的 Celery worker 未指定 `-Q`，只监听默认队列；现在消费 `celery,processing,video,notification,upload`。本地脚本 `start_autoclip.sh` 同步补齐 `celery` 与 `video` 队列（#88）
@@ -25,7 +33,9 @@
 - `docker-compose.yml` 四个服务共用 `autoclip:local` 镜像，只需构建一次
 - CI 新增 `docker-smoke` job：构建镜像、拉起 redis + api + worker、校验健康检查、yt-dlp 可用、REDIS_URL 连通、worker 监听了全部路由队列
 - 桌面壳启动后端时注入 `AUTOCLIP_APP_VERSION`，后端 `/settings` 不再固定返回 `1.0.0`
+- 桌面壳按平台设置数据目录 `AUTOCLIP_APP_DIR`（macOS 路径不变；Windows 为 `%APPDATA%\AutoClip`），Windows 下强制 `PYTHONUTF8=1` 且不弹控制台窗口
 - `src-tauri/Cargo.toml` 版本与 `tauri.conf.json` 对齐
+- `desktop-build.yml` 改为 macOS + Windows 并行构建，`release` job 汇总产物，单一平台失败不阻塞另一平台上传
 
 ### 移除
 - 删除无任何引用的 `backend/api/v1/youtube_improved.py`

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -144,9 +144,19 @@ DATABASE_URL=sqlite:///./data/autoclip.db
 # Redis配置
 REDIS_URL=redis://redis:6379/0
 
-# API配置
-API_DASHSCOPE_API_KEY=your_dashscope_api_key
+# LLM 配置（Docker 里没有设置页，只能靠这里；compose 会把这些变量透传给 api 和 worker）
+# LLM_PROVIDER: dashscope | openai | gemini | siliconflow
+LLM_PROVIDER=dashscope
 API_MODEL_NAME=qwen-plus
+API_DASHSCOPE_API_KEY=your_dashscope_api_key
+# API_OPENAI_API_KEY=
+# API_GEMINI_API_KEY=
+# API_SILICONFLOW_API_KEY=
+# OpenAI 兼容接口（LLM_PROVIDER=openai 时生效）：智谱 / DeepSeek / OpenRouter / 本地 Ollama、vLLM 都走这条。
+#   智谱:    OPENAI_BASE_URL=https://open.bigmodel.cn/api/paas/v4   API_MODEL_NAME=glm-4-flash
+#   DeepSeek: OPENAI_BASE_URL=https://api.deepseek.com/v1          API_MODEL_NAME=deepseek-chat
+#   宿主机 Ollama: OPENAI_BASE_URL=http://host.docker.internal:11434/v1  API_MODEL_NAME=qwen2.5:7b（可不填 key）
+# OPENAI_BASE_URL=
 
 # 日志配置
 LOG_LEVEL=INFO

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,6 +1,6 @@
 # AutoClip — 项目状态 / 进度 / 计划
 
-> 更新：2026-09-06 · 基于 `main@17100c0`（v1.2.0）+ 分支 `cursor/v1.2.1-docker-hotfix-85bc`
+> 更新：2026-09-06 · 基于 `main@992239a`（#89 #90 #91 #92 #93 #94 已全部合入，v1.2.1 待打 tag）
 
 AutoClip 是一款 AI 视频切片工具：输入 B站/YouTube 链接或本地视频，自动识别精彩片段、
 生成切片与合集。本文是项目当前状态与近期计划的单一事实来源；长期规划见 `ROADMAP.md`。
@@ -14,9 +14,9 @@ AutoClip 是一款 AI 视频切片工具：输入 B站/YouTube 链接或本地�
 | 后端 | FastAPI + Celery（桌面模式用本地线程）+ SQLite | `backend/` |
 | 前端 | React + TypeScript + Ant Design + Vite | `frontend/` |
 | 桌面壳 | Tauri 2 + Rust | `src-tauri/` |
-| LLM | OpenAI / Gemini(google-genai) / 通义千问(dashscope) / 硅基流动 | `backend/core/llm_providers.py` |
+| LLM | OpenAI 及一切 OpenAI 兼容接口（自定义 base_url）/ Gemini(google-genai) / 通义千问(dashscope) / 硅基流动 | `backend/core/llm_providers.py`、`llm_manager.py` |
 
-三种交付形态：**桌面客户端**（macOS arm64 DMG，主推）、**Docker 部署**（README 推荐路径）、
+三种交付形态：**桌面客户端**（macOS arm64 DMG 主推；Windows x64 安装包首版待验证）、**Docker 部署**（README 推荐路径）、
 **本地脚本启动**（`start_autoclip.sh`）。
 
 ---
@@ -30,9 +30,9 @@ AutoClip 是一款 AI 视频切片工具：输入 B站/YouTube 链接或本地�
 - **Calm Premium 视觉系统**落地（`DESIGN.md`）。
 - Nightly 后端冒烟（`nightly-desktop-smoke.yml`）持续全绿。
 
-### v1.2.1 止血（本分支，待合并发版）
+### v1.2.1（已全部合入 main，待打 tag 发版）
 问题根源：README 推荐的 `docker compose` 路径从 2025-09 起就没能跑通过一次完整处理
-（issue #88 给出 7 条可复现问题，全部核验属实），是 issue 区大量"用不了"的来源。本分支修复：
+（issue #88 给出 7 条可复现问题，全部核验属实），是 issue 区大量"用不了"的来源。#89 修复：
 1. `.dockerignore` 放行 `docker-entrypoint.sh` / `docker-dev-entrypoint.sh`（镜像此前无法构建）
 2. 新增 `.gitattributes`，shell 脚本强制 LF（Windows 克隆后容器起不来）
 3. 清理 `youtube.py` / `fix_project_thumbnails.py` / `SettingsPage.tsx` 里的 `/Users/zhoukk` 硬编码
@@ -44,28 +44,34 @@ AutoClip 是一款 AI 视频切片工具：输入 B站/YouTube 链接或本地�
 8. `_build_full_input` list 输入 JSON 序列化（#53）
 9. CI 新增 `docker-smoke` job 守住以上路径；版本号对齐到 1.2.1；删除死代码 `youtube_improved.py`
 
+随后合入：
+- **#90** 清掉 6 个 `NodeJS.Timeout` 类型错误，`npm run typecheck` 在 CI 阻断
+- **#91** 外部 PR #85（日志 utf-8）、#84（Gemini `-latest` 别名）、#83（youtube.py 五连修）以 cherry-pick 合入（保留原作者署名；原 PR 需手动关闭）
+- **#94** `requirements.txt` 直接依赖全部锁定
+- **#92** OpenAI 兼容 `base_url`（#72 #57，替代 #78）。**顺带发现并修复：设置页选的 provider 从来没被持久化，流水线一直用 dashscope**；
+  LLMManager 现按 settings.json mtime 热重载，且支持 Docker 环境变量（`LLM_PROVIDER` / `OPENAI_BASE_URL` / `API_*_API_KEY`）
+- **#93** Windows x64 打包脚本 + workflow（未在真机跑过，见下方 todo）
+
 ### 仍未完成（ROADMAP Phase 0）
 | 项 | 状态 |
 |---|---|
 | Apple Developer ID 签名 + 公证 | 未做，`signingIdentity: null`，用户需右键打开 |
-| 多平台包（Windows / Intel mac / Linux） | 未做；Windows 是 issue 里最大的单一需求（#2 #19 #35 #73 #86） |
+| 多平台包（Windows / Intel mac / Linux） | Windows x64 脚本 + workflow 已合入（#93）但**尚未在 Windows runner 上跑过**；Intel mac / Linux 未做 |
 | Sentry 崩溃上报 | 未接 |
 | Tauri updater 自动更新 | 未接 |
-| 依赖锁版本 / 构建缓存 | 未做 |
-| `ruff` / `npm run typecheck` 在 CI 中仍是 `continue-on-error` | 6 个 `NodeJS.Timeout` 类型错误待清 |
+| 依赖锁版本 / 构建缓存 | 直接依赖已锁定（#94）；PBS + ffmpeg 下载有 actions/cache，Rust 有 rust-cache |
+| `ruff` 在 CI 中仍是 `continue-on-error` | typecheck 已阻断（#90）；ruff 存量 ~130 条多为风格规则，需先收敛规则集再阻断 |
 
 ---
 
 ## 三、GitHub 待办快照（2026-09-06）
 
-### Open PR（9 个，均未 review；外部贡献者的 CI 需维护者在 Actions 里批准后才会跑）
+### Open PR（外部；本仓库自己的 6 个 PR 已全部合入）
 | PR | 建议 |
 |----|------|
-| #85 日志 FileHandler `encoding="utf-8"` | 合并，无风险 |
-| #84 Gemini 改用 `-latest` 模型别名 | 合并前用真实 key 调一次 |
-| #83 `youtube.py` 五连修（cookie 回退、字幕/视频拆分下载、`Path` 遮蔽、`project_name` 可选） | 合并；与本分支在 `youtube.py` 有小冲突，谁后合谁 rebase |
+| #85 #84 #83 | **已通过 #91 合入**（cherry-pick），GitHub 不会自动关闭 → 手动关闭并留言致谢 + 指向 #91 |
+| #78 Atlas Cloud provider | **已被 #92 替代**：设置页 OpenAI 提供商填 base_url 即可接 Atlas Cloud → 留言后关闭 |
 | #79 README star chart | 确认新图表域名可信后合并 |
-| #78 Atlas Cloud provider | 引导改为通用「OpenAI-compatible + 自定义 base_url」provider，一并解决 #72 #57 |
 | #75 TwelveLabs Pegasus 评分（opt-in） | 先定义"Step 3 评分后端可插拔"接口再接；SDK 放 extra 而非主 requirements |
 | #82 1080p60 + 全英文 prompt/UI + 迁移脚本（49 文件） | 要求拆分，否则关闭 |
 | #86 Windows `.vbs` 开发态启动器 | 关闭或移入 `scripts/`；真正需求是 Windows 安装包 |
@@ -84,17 +90,23 @@ AutoClip 是一款 AI 视频切片工具：输入 B站/YouTube 链接或本地�
 
 ## 四、迭代计划
 
-### v1.2.1（本分支）→ 发版
-- [ ] 合并本分支；在 Actions 批准并合并 #85 #84 #83
-- [ ] 打 `v1.2.1` tag（`desktop-build.yml` 自动出 DMG）
-- [ ] 建 label 体系并给 issue 打标；关闭上表"可关闭"项，置顶一个「已知问题与当前状态」issue
+### v1.2.1 发版（代码已齐，剩人工动作）
+- [x] 合并 #89 #90 #91 #92 #93 #94
+- [ ] **先在 Actions 手动 `workflow_dispatch` `Desktop Build`，只勾 Windows**，看 NSIS 包能否产出；
+      装到一台干净 Windows 上验证：能启动、设置页保存 provider、跑通一条本地视频
+      （最可能翻车的点：NSIS 打几千个 Python 文件耗时、WebView2 引导、`%APPDATA%\AutoClip` 目录）
+- [ ] 打 `v1.2.1` tag → mac + Windows 并行构建，`release` job 自动挂产物（Windows 失败不影响 DMG）
+- [ ] 用真实 key 各测一遍 4 个 provider 的「测试连接」+ 一次完整处理（#92 改动了 provider 选择链路，单测覆盖了逻辑但没打过真接口；尤其 openai SDK 已是 3.x）
+- [ ] 关闭已修复 issue：#88 #47 #50 #51 #52 #53 #54 #55 #62 #73（Windows 包出来后）；关闭外部 PR #83 #84 #85 #78（见上表）
+- [ ] 建 label 体系（bug / docker / windows / feature / question / invalid）并给 issue 打标；置顶一个「已知问题与当前状态」issue，把"用不了"类（#7 #26 #30 #31 #32 #39 #42 #43 #59）统一回复到 v1.2.1
 
-### v1.3 · 补齐 Phase 0 + 最高频需求
-- [ ] OpenAI-compatible provider 支持自定义 `base_url`（#72 #57，吸收 #78）
-- [ ] `build_macos_arm.sh` 参数化 runner / PBS URL / ffmpeg URL / tauri target → Windows x64 包，再 Intel mac
-- [ ] Apple 签名 + 公证；Tauri updater；Sentry
-- [ ] 锁定 `requirements.txt`；缓存 PBS + 依赖
-- [ ] 清掉 6 个 `NodeJS.Timeout` 错误，`ruff` / `typecheck` 改为阻断
+### v1.3 · Phase 0 收尾 + 高频需求
+- [ ] Windows 包稳定后：Intel mac（PBS `x86_64-apple-darwin` + osxexperts intel 静态包，脚本只需改两个变量）
+- [ ] Apple Developer ID 签名 + 公证（去掉"右键打开"）；Windows 代码签名（去掉 SmartScreen 警告）
+- [ ] Tauri updater 自动更新；Sentry 崩溃上报
+- [ ] `ruff` 规则集收敛后改为阻断；`requirements-dev.txt` 拆出 pytest（Dockerfile / 桌面包不再装测试依赖）
+- [ ] 设置页 provider 卡片 / 彩色 Tag 与 `DESIGN.md`（近乎单色、只用一个蓝）不符，改造时一并处理
+- [ ] Docker 模式下开放设置页（目前 `check_desktop_mode` 直接 400，只能靠 .env）
 
 ### v1.4 · 产品质量
 - [ ] 切片质量回归集（#59 "5 分钟视频切出 3 个 2 分钟"、#11 切片为 0、#24 进度）
@@ -105,12 +117,12 @@ AutoClip 是一款 AI 视频切片工具：输入 B站/YouTube 链接或本地�
 
 ## 五、关键文件
 
-- 打包脚本：`scripts/build_macos_arm.sh`（说明见 `scripts/README.md`、`BUILD_GUIDE.md`）
-- 后端启动器（Rust）：`src-tauri/src/backend_manager.rs`（注入 `AUTOCLIP_DESKTOP_MODE` / ffmpeg 路径 / `AUTOCLIP_APP_VERSION`）
+- 打包脚本：`scripts/build_macos_arm.sh`、`scripts/build_windows_x64.sh`，共用 `scripts/lib/desktop_build_common.sh`（说明见 `scripts/README.md`）；Windows 资源声明在 `src-tauri/tauri.windows.conf.json`
+- 后端启动器（Rust）：`src-tauri/src/backend_manager.rs`（注入 `AUTOCLIP_DESKTOP_MODE` / `AUTOCLIP_APP_DIR` / ffmpeg 路径 / `AUTOCLIP_APP_VERSION`；Windows 下 `PYTHONUTF8=1`）
 - 桌面后端入口：`backend/desktop_main.py`
 - 任务提交（桌面本地线程 vs Celery）：`backend/utils/task_submission_utils.py`、`backend/core/celery_app.py`（DesktopAwareTask、task_routes）
 - ffmpeg 路径解析：`backend/utils/ffmpeg_utils.py`
-- LLM 提供商：`backend/core/llm_providers.py`
+- LLM 提供商：`backend/core/llm_providers.py`；provider / base_url 选择与热重载：`backend/core/llm_manager.py`；设置 API：`backend/api/v1/settings.py`
 - YouTube 导入：`backend/api/v1/youtube.py`（`AUTOCLIP_YT_SUBTITLE_LANGS`、`AUTOCLIP_YT_CLIENT`）
 - Whisper 运行时（按需安装）：`backend/services/whisper_runtime.py`、`whisper_model_manager.py`、
   前端 `frontend/src/components/SpeechRecognitionConfig.tsx`

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -33,6 +33,16 @@ services:
       - ENVIRONMENT=development
       - DEBUG=true
       - LOG_LEVEL=DEBUG
+      # LLM 配置从宿主机 .env / shell 透传（compose 会自动读项目根目录的 .env 做变量替换）。
+      # 没有这一段时 DOCKER.md 里让用户填的 API_DASHSCOPE_API_KEY 根本进不了容器。
+      - LLM_PROVIDER=${LLM_PROVIDER:-dashscope}
+      - API_MODEL_NAME=${API_MODEL_NAME:-qwen-plus}
+      - API_DASHSCOPE_API_KEY=${API_DASHSCOPE_API_KEY:-}
+      - API_OPENAI_API_KEY=${API_OPENAI_API_KEY:-}
+      - OPENAI_BASE_URL=${OPENAI_BASE_URL:-}
+      - API_GEMINI_API_KEY=${API_GEMINI_API_KEY:-}
+      - API_SILICONFLOW_API_KEY=${API_SILICONFLOW_API_KEY:-}
+      - AUTOCLIP_YT_SUBTITLE_LANGS=${AUTOCLIP_YT_SUBTITLE_LANGS:-}
     depends_on:
       - redis
     command: >
@@ -64,6 +74,16 @@ services:
       - ENVIRONMENT=development
       - DEBUG=true
       - LOG_LEVEL=DEBUG
+      # LLM 配置从宿主机 .env / shell 透传（compose 会自动读项目根目录的 .env 做变量替换）。
+      # 没有这一段时 DOCKER.md 里让用户填的 API_DASHSCOPE_API_KEY 根本进不了容器。
+      - LLM_PROVIDER=${LLM_PROVIDER:-dashscope}
+      - API_MODEL_NAME=${API_MODEL_NAME:-qwen-plus}
+      - API_DASHSCOPE_API_KEY=${API_DASHSCOPE_API_KEY:-}
+      - API_OPENAI_API_KEY=${API_OPENAI_API_KEY:-}
+      - OPENAI_BASE_URL=${OPENAI_BASE_URL:-}
+      - API_GEMINI_API_KEY=${API_GEMINI_API_KEY:-}
+      - API_SILICONFLOW_API_KEY=${API_SILICONFLOW_API_KEY:-}
+      - AUTOCLIP_YT_SUBTITLE_LANGS=${AUTOCLIP_YT_SUBTITLE_LANGS:-}
     command: >
       sh -c "
         source venv/bin/activate &&

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,16 @@ services:
       - ENVIRONMENT=production
       - DEBUG=false
       - LOG_LEVEL=INFO
+      # LLM 配置从宿主机 .env / shell 透传（compose 会自动读项目根目录的 .env 做变量替换）。
+      # 没有这一段时 DOCKER.md 里让用户填的 API_DASHSCOPE_API_KEY 根本进不了容器。
+      - LLM_PROVIDER=${LLM_PROVIDER:-dashscope}
+      - API_MODEL_NAME=${API_MODEL_NAME:-qwen-plus}
+      - API_DASHSCOPE_API_KEY=${API_DASHSCOPE_API_KEY:-}
+      - API_OPENAI_API_KEY=${API_OPENAI_API_KEY:-}
+      - OPENAI_BASE_URL=${OPENAI_BASE_URL:-}
+      - API_GEMINI_API_KEY=${API_GEMINI_API_KEY:-}
+      - API_SILICONFLOW_API_KEY=${API_SILICONFLOW_API_KEY:-}
+      - AUTOCLIP_YT_SUBTITLE_LANGS=${AUTOCLIP_YT_SUBTITLE_LANGS:-}
     depends_on:
       redis:
         condition: service_healthy
@@ -65,6 +75,16 @@ services:
       - ENVIRONMENT=production
       - DEBUG=false
       - LOG_LEVEL=INFO
+      # LLM 配置从宿主机 .env / shell 透传（compose 会自动读项目根目录的 .env 做变量替换）。
+      # 没有这一段时 DOCKER.md 里让用户填的 API_DASHSCOPE_API_KEY 根本进不了容器。
+      - LLM_PROVIDER=${LLM_PROVIDER:-dashscope}
+      - API_MODEL_NAME=${API_MODEL_NAME:-qwen-plus}
+      - API_DASHSCOPE_API_KEY=${API_DASHSCOPE_API_KEY:-}
+      - API_OPENAI_API_KEY=${API_OPENAI_API_KEY:-}
+      - OPENAI_BASE_URL=${OPENAI_BASE_URL:-}
+      - API_GEMINI_API_KEY=${API_GEMINI_API_KEY:-}
+      - API_SILICONFLOW_API_KEY=${API_SILICONFLOW_API_KEY:-}
+      - AUTOCLIP_YT_SUBTITLE_LANGS=${AUTOCLIP_YT_SUBTITLE_LANGS:-}
     # 任务通过 celery_app.task_routes 被路由到专用队列；不带 -Q 的 worker 只消费默认的
     # `celery` 队列，流水线任务会一直堆在 `processing` 里没人执行，项目永远卡在处理中。
     command: celery -A backend.core.celery_app worker --loglevel=info --concurrency=2 -Q celery,processing,video,notification,upload


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Follow-up after #89–#94 landed on `main`.

While writing the Docker LLM docs I found that `docker-compose.yml` only sets five fixed `environment` entries and never reads the host `.env`, so the `API_DASHSCOPE_API_KEY` that `DOCKER.md` has always told users to put in `.env` never reached the containers. With #92 the backend finally reads those variables — this PR makes compose deliver them.

## What

- **`docker-compose.yml` / `docker-compose.dev.yml`**: `autoclip` and `celery-worker` (and the dev equivalents) receive `LLM_PROVIDER`, `API_MODEL_NAME`, `OPENAI_BASE_URL`, `API_{DASHSCOPE,OPENAI,GEMINI,SILICONFLOW}_API_KEY`, `AUTOCLIP_YT_SUBTITLE_LANGS` via `${VAR:-default}` interpolation (compose reads the project-root `.env` for this on every version, unlike `env_file: required: false`).
- **CI `docker-smoke`**: writes a throwaway `.env` (`LLM_PROVIDER=openai`, custom `OPENAI_BASE_URL`, model) before `compose up` and asserts `LLMManager().get_current_provider_info()` resolves it inside **both** the api and the worker container.
- **`DOCKER.md`**: LLM section with Zhipu / DeepSeek / host-Ollama (`host.docker.internal`) examples.
- **`CHANGELOG.md` 1.2.1**: entries for #92 (base_url + the un-persisted-provider fix), #93 (Windows package), #94 (pinned deps), compose/CI changes.
- **`HANDOFF.md`**: snapshot for `main@992239a`, PR table updated (#83/#84/#85 merged via #91 and #78 superseded → need manual close), the remaining manual release steps, and the v1.3 todo.

## Verification

- YAML parses; no Docker CLI in this environment, so the compose interpolation and the new smoke assertion are exercised by this PR's own `docker-smoke` job.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a076e0-b655-7492-b632-bb1d09bb85bc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a076e0-b655-7492-b632-bb1d09bb85bc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

