### PR TITLE
docs: 手动启动的 Celery worker 补上 -Q 队列参数（否则流水线任务无人消费）

### DIFF
--- a/.github/README-EN.md
+++ b/.github/README-EN.md
@@ -508,8 +508,9 @@ npm run dev
 ### Celery Worker
 
 ```bash
-# Start Worker
-celery -A backend.core.celery_app worker --loglevel=info
+# Start Worker (must include -Q: tasks are routed to dedicated queues via celery_app.task_routes;
+# a worker without -Q only consumes the default `celery` queue, so pipeline tasks pile up in `processing` and never run)
+celery -A backend.core.celery_app worker --loglevel=info -Q celery,processing,video,notification,upload
 
 # Start Beat scheduler
 celery -A backend.core.celery_app beat --loglevel=info

--- a/.github/README.md
+++ b/.github/README.md
@@ -493,8 +493,9 @@ npm run dev
 ### Celery Worker
 
 ```bash
-# 启动Worker
-celery -A backend.core.celery_app worker --loglevel=info
+# 启动Worker（必须带 -Q：任务按 celery_app.task_routes 路由到专用队列，
+# 不带 -Q 的 worker 只消费默认 `celery` 队列，流水线任务会一直堆在 `processing` 里没人执行）
+celery -A backend.core.celery_app worker --loglevel=info -Q celery,processing,video,notification,upload
 
 # 启动Beat调度器
 celery -A backend.core.celery_app beat --loglevel=info

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,8 +49,8 @@ brew services start redis  # macOS
 # 启动后端
 python -m uvicorn backend.main:app --reload --port 8000
 
-# 启动Celery Worker
-celery -A backend.core.celery_app worker --loglevel=info
+# 启动Celery Worker（必须带 -Q，否则只消费默认 `celery` 队列，流水线任务无人执行）
+celery -A backend.core.celery_app worker --loglevel=info -Q celery,processing,video,notification,upload
 
 # 启动前端
 cd frontend && npm run dev

--- a/README-EN.md
+++ b/README-EN.md
@@ -512,8 +512,9 @@ npm run dev
 ### Celery Worker
 
 ```bash
-# Start Worker
-celery -A backend.core.celery_app worker --loglevel=info
+# Start Worker (must include -Q: tasks are routed to dedicated queues via celery_app.task_routes;
+# a worker without -Q only consumes the default `celery` queue, so pipeline tasks pile up in `processing` and never run)
+celery -A backend.core.celery_app worker --loglevel=info -Q celery,processing,video,notification,upload
 
 # Start Beat scheduler
 celery -A backend.core.celery_app beat --loglevel=info

--- a/README.md
+++ b/README.md
@@ -500,8 +500,9 @@ npm run dev
 ### Celery Worker
 
 ```bash
-# 启动Worker
-celery -A backend.core.celery_app worker --loglevel=info
+# 启动Worker（必须带 -Q：任务按 celery_app.task_routes 路由到专用队列，
+# 不带 -Q 的 worker 只消费默认 `celery` 队列，流水线任务会一直堆在 `processing` 里没人执行）
+celery -A backend.core.celery_app worker --loglevel=info -Q celery,processing,video,notification,upload
 
 # 启动Beat调度器
 celery -A backend.core.celery_app beat --loglevel=info

--- a/STARTUP_GUIDE.md
+++ b/STARTUP_GUIDE.md
@@ -212,8 +212,9 @@ npm run dev
 ### Celery Worker
 
 ```bash
-# 启动Worker
-celery -A backend.core.celery_app worker --loglevel=info
+# 启动Worker（必须带 -Q：任务按 celery_app.task_routes 路由到专用队列，
+# 不带 -Q 的 worker 只消费默认 `celery` 队列，流水线任务会一直堆在 `processing` 里没人执行）
+celery -A backend.core.celery_app worker --loglevel=info -Q celery,processing,video,notification,upload
 
 # 启动Beat调度器
 celery -A backend.core.celery_app beat --loglevel=info

--- a/quick_start.sh
+++ b/quick_start.sh
@@ -86,7 +86,7 @@ main() {
     
     # 启动Celery Worker
     log_info "启动Celery Worker..."
-    nohup celery -A backend.core.celery_app worker --loglevel=info --concurrency=1 --prefetch-multiplier=1 -Q processing,upload,notification,maintenance > logs/celery.log 2>&1 &
+    nohup celery -A backend.core.celery_app worker --loglevel=info --concurrency=1 --prefetch-multiplier=1 -Q celery,processing,video,notification,upload > logs/celery.log 2>&1 &
     echo $! > celery.pid
     
     # 启动前端


### PR DESCRIPTION
## 问题

本地（非 Docker）按文档手动启动时，Celery worker 命令不带 `-Q`：

```bash
celery -A backend.core.celery_app worker --loglevel=info   # 文档现状
```

而 `backend/core/celery_app.py` 的 `task_routes` 把 `processing.*` / `video.*` / `notification.*` / `upload.*` 路由到了专用队列。不带 `-Q` 的 worker 只消费默认 `celery` 队列，结果：

- 视频下载完成后流水线任务提交到 `processing` 队列（日志可见「Redis 队列 processing 深度: 1」），但没有任何 worker 消费；
- 项目状态永远停在「处理中」、进度 0%。

`docker-compose.yml`（L88-90 注释即此问题）与 `start_autoclip.sh` 早已带正确参数，只是文档与 `quick_start.sh` 没同步。

## 修改

- `README.md` / `README-EN.md` / `STARTUP_GUIDE.md` / `CONTRIBUTING.md`（含 `.github/` 下两个镜像副本）：worker 命令统一补 `-Q celery,processing,video,notification,upload`，并加一行注释说明原因；
- `quick_start.sh`：原队列清单 `-Q processing,upload,notification,maintenance` 列出了**不存在的 maintenance 队列**（maintenance 任务按默认路由走 `celery` 队列），且漏掉 `celery` 与 `video`（导致视频切片提取任务无人执行），统一为同一份正确清单。

## 验证

- [x] 本地实测：不带 `-Q` 启动 worker → 任务积压 `processing` 队列、进度 0%；带 `-Q celery,processing,video,notification,upload` 重启后任务立即被消费（与本 PR 中文档命令一致）
- [x] `bash -n quick_start.sh` 语法检查通过