### PR TITLE
fix(frontend): drop unused eslint-disable directive that fails CI on main

### DIFF
--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -245,7 +245,6 @@ const SettingsPage: React.FC = () => {
   // 打开设置页时若已是本地预设，顺手探测一次
   useEffect(() => {
     if (isLocalProvider(selectedProvider)) void detectLocalModels(selectedProvider, form.getFieldValue('local_base_url'))
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedProvider])
 
   const openaiBaseUrl = Form.useWatch('openai_base_url', form)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

`CI` on `main` has been red since commit `9f81b5c` (开发者形态：CLI / MCP / 本地模型预设), runs [34052532587](https://github.com/zhouxiaoka/autoclip/actions/runs/34052532587) and [34074043040](https://github.com/zhouxiaoka/autoclip/actions/runs/34074043040). Only the *Frontend checks* job fails; backend tests and docker-smoke pass.

```
frontend/src/pages/SettingsPage.tsx
  248:5  error  Unused eslint-disable directive (no problems were reported from 'react-hooks/exhaustive-deps')
```

`react-hooks/exhaustive-deps` is set to `off` globally in `.eslintrc.cjs`, so the `// eslint-disable-next-line react-hooks/exhaustive-deps` added above the `useEffect` in that commit never suppresses anything, and `npm run lint` runs with `--report-unused-disable-directives --max-warnings 0`, which turns that into a hard error.

## What

Removed the one-line directive. No behaviour change.

## Verification

`npm run lint`, `npm run typecheck`, `npm run build` all pass locally on this branch.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a076e0-b655-7492-b632-bb1d09bb85bc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a076e0-b655-7492-b632-bb1d09bb85bc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

